### PR TITLE
fix: RSS feed links

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,7 +14,7 @@
   </div>
   {{- end }}
   <div class="post-description">
-    <a href="{{ .Permalink }}/index.xml" target="_blank"><u>Subscribe via RSS</u></a> to get updates for "{{ .Title }}".
+    <a href="{{ .Permalink }}index.xml" target="_blank"><u>Subscribe via RSS</u></a> to get updates for "{{ .Title }}".
   </div>
 </header>
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Fix double slash in RSS feeds link.