### PR TITLE
remove tags and categories from newsletters and playground, update fastsearch to use section names to filter, add section names to index, update search boxes to use section names instead of category names

### DIFF
--- a/archetypes/dailies.md
+++ b/archetypes/dailies.md
@@ -3,6 +3,4 @@ title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---

--- a/archetypes/newsletters.md
+++ b/archetypes/newsletters.md
@@ -5,8 +5,6 @@ draft: true
 ShowToc: true
 TocOpen: true
 summary: ""
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 ## What's Happening?

--- a/archetypes/playgrounds.md
+++ b/archetypes/playgrounds.md
@@ -5,8 +5,6 @@ experimental: true
 EnableCodapi: true
 CodapiURL: 127.0.0.1:1314/v1
 ShowCodeCopyButtons: false
-tags: ["playground", "codapi"]
-categories: ["Playground"]
 cover:
     image: "/images/pl-{{ .Name }}/"
     alt: ""

--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -24,12 +24,12 @@ window.onload = function () {
         // Filter data based on "showOnly" and "omit"
         if (showOnly) {
           data = data.filter(function (item) {
-            return item.categories.indexOf(showOnly) !== -1;
+            return item.section.indexOf(showOnly) !== -1;
           });
         } else if (omitValues.length > 0) {
           data = data.filter(function (item) {
             return omitValues.every(function (value) {
-              return item.categories.indexOf(value) === -1;
+              return item.section.indexOf(value) === -1;
             });
           });
         }
@@ -39,7 +39,7 @@ window.onload = function () {
             distance: 100,
             threshold: 0.4,
             ignoreLocation: true,
-            keys: ["title", "permalink", "summary", "content", "categories"],
+            keys: ["title", "permalink", "summary", "content", "categories", "section"],
           };
           if (params.fuseOpts) {
             options = {
@@ -55,6 +55,7 @@ window.onload = function () {
                 "summary",
                 "content",
                 "categories",
+                "section",
               ],
               location: params.fuseOpts.location ?? 0,
               threshold: params.fuseOpts.threshold ?? 0.4,

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -14,7 +14,7 @@ This blog is a window into my world as an open source maintainer and an amateur 
 
 I write about a [wide range of topics](/categories/), from in-depth [tutorials for projects](/tags/apache-apisix/) that keep me up at night to the [goals in life](/tags/life/) that keep me inspired.
 
-I also try to [write daily](/categories/daily-dose-of-pottekkat/), but fair warning: I don't stop to edit these.
+I also try to [write daily](/dailies/), but fair warning: I don't stop to edit these.
 
 Unless mentioned otherwise, all material in this blog is licensed under [CC BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0), and the [source code](https://github.com/pottekkat/personal-website) of this website is available under the [MIT license](https://github.com/pottekkat/personal-website/blob/hugo/LICENSE).
 

--- a/content/dailies/1-1-22-goals-for-2022.md
+++ b/content/dailies/1-1-22-goals-for-2022.md
@@ -4,8 +4,6 @@ date: 2022-01-01T18:15:25+05:30
 draft: false
 ShowToc: false
 summary: "My goals for 2022, publicly posted for accountability."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I don't usually set concrete goals for the year but instead choose to go with the flow.

--- a/content/dailies/1-2-22-i-am-sick.md
+++ b/content/dailies/1-2-22-i-am-sick.md
@@ -3,8 +3,6 @@ title: "#31 I'm Sick"
 date: 2022-02-01T09:33:10+05:30
 draft: false
 summary: "I am suddenly sick."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Aaaaaaaah!

--- a/content/dailies/1-2-23-here-and-now.md
+++ b/content/dailies/1-2-23-here-and-now.md
@@ -3,8 +3,6 @@ title: "#236 Here and Now"
 date: 2023-02-01T13:01:34+05:30
 draft: false
 summary: "/now"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 [A year ago](/dailies/1-2-22-i-am-sick), I was playing Wordle and was sick. I’m healthy now, but I tried today’s Wordle:

--- a/content/dailies/1-3-22-working-in-open-source.md
+++ b/content/dailies/1-3-22-working-in-open-source.md
@@ -3,8 +3,6 @@ title: "#57 Working in Open Source"
 date: 2022-03-01T15:35:07+05:30
 draft: false
 summary: "Do you want to work for [insert large consulting company from India]?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/1-4-22-project-ideas.md
+++ b/content/dailies/1-4-22-project-ideas.md
@@ -3,8 +3,6 @@ title: "#88 Project Ideas"
 date: 2022-04-01T12:19:45+05:30
 draft: false
 summary: "What do you do when you get new ideas?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🥲

--- a/content/dailies/1-4-23-stats.md
+++ b/content/dailies/1-4-23-stats.md
@@ -3,8 +3,6 @@ title: "#253 /stats"
 date: 2023-04-01T23:43:54+05:30
 draft: false
 summary: "/stats is here. Check it out."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It has been some time. I wanted to write here every day, but I have been super busy outside of work.

--- a/content/dailies/1-4-24-good-morning-vietnam.md
+++ b/content/dailies/1-4-24-good-morning-vietnam.md
@@ -3,8 +3,6 @@ title: "#278 Good Morning, Vietnam"
 date: 2024-04-01T20:11:21+05:30
 draft: false
 summary: "I will be in Hanoi for the FOSSASIA Summit 2024!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm [back](/dailies/14-2-24-welcome-my-communist-brother/) in Vietnam, this time for work. I will be at the [FOSSASIA Summit 2024](https://eventyay.com/e/55d2a466/) next week.

--- a/content/dailies/1-5-22-more-proposals.md
+++ b/content/dailies/1-5-22-more-proposals.md
@@ -3,8 +3,6 @@ title: "#117 More Proposals"
 date: 2022-05-01T19:15:39+05:30
 draft: false
 summary: "More talk proposals at conferences. Bonus: Photos!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I don't know a lot of words.

--- a/content/dailies/1-6-22-neichor.md
+++ b/content/dailies/1-6-22-neichor.md
@@ -3,8 +3,6 @@ title: "#145 Neichor"
 date: 2022-06-01T21:38:18+05:30
 draft: false
 summary: "Neichor and Chicken Curry is the best food you can eat."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The days when I have Neichor and Chicken Curry are the best days. That is the post today. And a picture of my dinner as a cheery on top.

--- a/content/dailies/1-9-22-conference-season.md
+++ b/content/dailies/1-9-22-conference-season.md
@@ -3,8 +3,6 @@ title: "#199 Conference Season"
 date: 2022-09-01T22:03:45+05:30
 draft: false
 summary: "Is it September already?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It's September, and Hacktoberfest folks are already out. Let's go for a spam free 22.

--- a/content/dailies/10-1-22-what-matters.md
+++ b/content/dailies/10-1-22-what-matters.md
@@ -3,8 +3,6 @@ title: "#11 What Matters"
 date: 2022-01-10T22:34:34+05:30
 draft: false
 summary: "But in the end, it doesn't even matter."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm taking time off work to shift my focus to finishing my Master's for the next one month.

--- a/content/dailies/10-1-23-whats-the-best-beer.md
+++ b/content/dailies/10-1-23-whats-the-best-beer.md
@@ -3,8 +3,6 @@ title: "#234 What's the Best Beer?"
 date: 2023-01-10T23:32:14+05:30
 draft: false
 summary: "The boys are back together beer."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The boys are back.

--- a/content/dailies/10-2-22-to-be-read.md
+++ b/content/dailies/10-2-22-to-be-read.md
@@ -3,8 +3,6 @@ title: "#39 To Be Read"
 date: 2022-02-10T10:13:34+05:30
 draft: false
 summary: "4 is par and 3 is a birdie."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 4 is par and 3 is a birdie.

--- a/content/dailies/10-2-23-singapore-day-2.md
+++ b/content/dailies/10-2-23-singapore-day-2.md
@@ -3,8 +3,6 @@ title: "#242 Singapore Day 2"
 date: 2023-02-10T23:05:33+08:00
 draft: false
 summary: "I went to the dentist today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 My filling fell out after dinner yesterday, and I was in a lot of pain. I went to the dentist, and all is well today.

--- a/content/dailies/10-3-22-catching-up-on-reading.md
+++ b/content/dailies/10-3-22-catching-up-on-reading.md
@@ -3,8 +3,6 @@ title: "#66 Catching Up on Reading"
 date: 2022-03-10T17:42:27+05:30
 draft: false
 summary: "Lot of emails and articles to catch up on."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Too many stupid guesses.

--- a/content/dailies/10-3-23-to-mumbaifoss.md
+++ b/content/dailies/10-3-23-to-mumbaifoss.md
@@ -3,8 +3,6 @@ title: "#248 To MumbaiFOSS"
 date: 2023-03-10T14:07:17+05:30
 draft: false
 summary: "Guess where I'm writing this from?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Guess where I'm writing this from? Yes, an airport.

--- a/content/dailies/10-4-22-hello-mumbai.md
+++ b/content/dailies/10-4-22-hello-mumbai.md
@@ -3,8 +3,6 @@ title: "#97 Hello Mumbai!"
 date: 2022-04-10T19:25:16+05:30
 draft: false
 summary: "Reached Mumbai today!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm Batman.

--- a/content/dailies/10-5-22-wordle-fever.md
+++ b/content/dailies/10-5-22-wordle-fever.md
@@ -3,8 +3,6 @@ title: "#126 Wordle Fever"
 date: 2022-05-10T10:35:20+05:30
 draft: false
 summary: "Wordle no more."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It's been some time since I shared my Wordle scores with my roommate. I think we are at a point where the game lost its charm.

--- a/content/dailies/10-6-22-jurassic-world-sucks.md
+++ b/content/dailies/10-6-22-jurassic-world-sucks.md
@@ -3,8 +3,6 @@ title: "#154 Jurassic World Sucks"
 date: 2022-06-10T23:17:05+05:30
 draft: false
 summary: "The new Jurassic World movie sucks."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I went to see the new Jurassic World movie and it sucked.

--- a/content/dailies/10-7-22-table-madness-and-red-bull-ring.md
+++ b/content/dailies/10-7-22-table-madness-and-red-bull-ring.md
@@ -3,8 +3,6 @@ title: "#166 Table Madness and Red Bull Ring"
 date: 2022-07-10T19:28:23+05:30
 draft: false
 summary: "Cricket match, Wimbledon finals, and race at the Red Bull Ring. I play table tennis."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Perez going DNF sucked, but it was a thrilling race.

--- a/content/dailies/10-8-22-six-seasons-and-a-movie.md
+++ b/content/dailies/10-8-22-six-seasons-and-a-movie.md
@@ -3,8 +3,6 @@ title: "#179 Six Seasons and a Movie"
 date: 2022-08-10T20:13:52+05:30
 draft: false
 summary: "Troy and Abed make a mooovie!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I forgot how great of a show Community was.

--- a/content/dailies/11-1-22-task-tracking-setup.md
+++ b/content/dailies/11-1-22-task-tracking-setup.md
@@ -3,8 +3,6 @@ title: "#12 Task Tracking Setup"
 date: 2022-01-11T22:46:42+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 A couple of months ago, my system to track tasks broke down.

--- a/content/dailies/11-12-22-last-week-tonight.md
+++ b/content/dailies/11-12-22-last-week-tonight.md
@@ -3,8 +3,6 @@ title: "#231 Last Week Tonight"
 date: 2022-12-11T16:35:32+05:30
 draft: false
 summary: "A lot of stuff happened in the past week."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It seems like I can only "write daily" on Sundays.

--- a/content/dailies/11-2-22-what-up-beaches.md
+++ b/content/dailies/11-2-22-what-up-beaches.md
@@ -3,8 +3,6 @@ title: "#40 What Up Beaches?"
 date: 2022-02-11T13:39:16+05:30
 draft: false
 summary: "Hitting beaches today with the gang."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 They moved Wordle to the NY Times website. I did today's in four tries but when I went to share the results, the platform was already changed and it did not have my today's play.

--- a/content/dailies/11-3-22-wordle-only-too-lazy.md
+++ b/content/dailies/11-3-22-wordle-only-too-lazy.md
@@ -3,8 +3,6 @@ title: "#67 Wordle Only, Too Lazy"
 date: 2022-03-11T21:27:04+05:30
 draft: false
 summary: "Too lazy to write. Working on presentation."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 265 6/6

--- a/content/dailies/11-4-22-four-unmerged-prs.md
+++ b/content/dailies/11-4-22-four-unmerged-prs.md
@@ -3,8 +3,6 @@ title: "#98 Four Unmerged PRs"
 date: 2022-04-11T20:31:21+05:30
 draft: false
 summary: "I opened two more PRs today. Now I have four open PRs."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The **, the whole **, and nothing but the \_\_.

--- a/content/dailies/11-4-23-airport-logs.md
+++ b/content/dailies/11-4-23-airport-logs.md
@@ -3,8 +3,6 @@ title: "#259 Airport Logs"
 date: 2023-04-11T19:19:15+05:30
 draft: false
 summary: "This might be a theme here."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm writing this again from an airport. I guess this is a thing now, considering I have written at least four daily logs in airports over the past months.

--- a/content/dailies/11-4-24-airplane-logs.md
+++ b/content/dailies/11-4-24-airplane-logs.md
@@ -3,8 +3,6 @@ title: "#279 Airplane Logs (FOSSASIA Summit 2024)"
 date: 2024-04-11T20:33:16+07:00
 draft: false
 summary: "Hello from the sky above Indian ocean."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Hello from the sky!

--- a/content/dailies/11-5-22-prepping-for-a-talk.md
+++ b/content/dailies/11-5-22-prepping-for-a-talk.md
@@ -3,8 +3,6 @@ title: "#127 Prepping for a Talk"
 date: 2022-05-11T19:15:31+05:30
 draft: false
 summary: "Talking at a meetup after months!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I will be talking about "Contributing to Open Source 101" tomorrow!

--- a/content/dailies/11-6-22-open-source-workshop.md
+++ b/content/dailies/11-6-22-open-source-workshop.md
@@ -3,8 +3,6 @@ title: "#155 Open Source Workshop"
 date: 2022-06-11T21:09:51+05:30
 draft: false
 summary: "Hosted an APISIX contributor workshop today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I hosted my first APISIX contributor workshop today. Although this is a first, I have some experience discussing open source contributions to students and new developers.

--- a/content/dailies/11-7-22-tiger.md
+++ b/content/dailies/11-7-22-tiger.md
@@ -3,8 +3,6 @@ title: "#167 Tiger"
 date: 2022-07-11T22:38:42+05:30
 draft: false
 summary: 'Prithviraj''s new movie "Kaduva" is as bad as I thought it would be.'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been going to the movies without reading reviews for some time now. Watching the new release Kaduva made me rethink this decision.

--- a/content/dailies/11-8-22-moving-to-netlify.md
+++ b/content/dailies/11-8-22-moving-to-netlify.md
@@ -3,8 +3,6 @@ title: "#180 Moving to Netlify"
 date: 2022-08-11T19:13:00+05:30
 draft: false
 summary: "I moved my Hugo blog from GitHub pages to Netlify."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was working on a new blog post. I wanted to publish it on my own blog first. But, it did not have a draft preview feature. I could set one up, but with my site being static, there are fewer options to receive feedback from reviewers.

--- a/content/dailies/12-10-22-new-drafts.md
+++ b/content/dailies/12-10-22-new-drafts.md
@@ -3,8 +3,6 @@ title: "#214 New Drafts"
 date: 2022-10-12T22:19:27+05:30
 draft: false
 summary: "New post on Kubernetes Gateway API coming soon."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Last week was a blast. I spent the weekend on my motorcycle and traveled close to 500 km.

--- a/content/dailies/12-11-22-internet-as-a-place-to-rant.md
+++ b/content/dailies/12-11-22-internet-as-a-place-to-rant.md
@@ -3,8 +3,6 @@ title: "#223 The Internet as a Place to Rant"
 date: 2022-11-12T16:53:46+05:30
 draft: false
 summary: "And the people who will listen your rants."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The internet is a place where you can talk about anything, and you will have an audience. This is far from my real life, where I can't just go to random people or friends/family and talk about sustaining open source projects.

--- a/content/dailies/12-2-23-garden-city-is-an-accurate-description.md
+++ b/content/dailies/12-2-23-garden-city-is-an-accurate-description.md
@@ -3,8 +3,6 @@ title: '#243 "Garden City" Is an Accurate Description'
 date: 2023-02-12T14:04:49+08:00
 draft: false
 summary: "It feels greener than Kerala."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Yesterday I got to meet APISIX PMC member Lien Li over dinner. It was a fun meeting.

--- a/content/dailies/12-3-22-codebar-festival.md
+++ b/content/dailies/12-3-22-codebar-festival.md
@@ -3,8 +3,6 @@ title: "#68 Codebar Festival"
 date: 2022-03-12T14:31:23+05:30
 draft: false
 summary: "I'm speaking at the Codebar Festival today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle can't beat me today.

--- a/content/dailies/12-4-22-visa-day-and-one-unmerged-pr.md
+++ b/content/dailies/12-4-22-visa-day-and-one-unmerged-pr.md
@@ -3,8 +3,6 @@ title: "#99 Visa Day and One Unmerged PR"
 date: 2022-04-12T21:23:32+05:30
 draft: false
 summary: "My three PRs from yesterday was merged. Only one remains."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 What is better than a flush?

--- a/content/dailies/12-5-22-the-talk.md
+++ b/content/dailies/12-5-22-the-talk.md
@@ -3,8 +3,6 @@ title: "#128 The Talk"
 date: 2022-05-12T19:18:22+05:30
 draft: false
 summary: "Talked at a meetup after months!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Last time I gave a talk was in February. It has been a long gap compared to my previous schedule where I spoke at least once a month.

--- a/content/dailies/12-6-22-race-day.md
+++ b/content/dailies/12-6-22-race-day.md
@@ -3,8 +3,6 @@ title: "#156 Race Day"
 date: 2022-06-12T22:43:11+05:30
 draft: false
 summary: "Azerbaijan GP is on!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 What a race in Azerbaijan today. It sucks to be team Ferrari, but I'm happy for RedBull scoring maximum points.

--- a/content/dailies/12-7-22-lulu.md
+++ b/content/dailies/12-7-22-lulu.md
@@ -3,8 +3,6 @@ title: "#168 LuLu"
 date: 2022-07-12T22:42:23+05:30
 draft: false
 summary: "Mandatory stop at the new LuLu mall when you are in Trivandrum."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Went to Trivandrum's own LuLu mall today. It looks bigger than last time.

--- a/content/dailies/12-8-22-new-blog-post-after-six-months.md
+++ b/content/dailies/12-8-22-new-blog-post-after-six-months.md
@@ -3,8 +3,6 @@ title: "#181 New Blog Post After Six Months"
 date: 2022-08-12T20:33:33+05:30
 draft: false
 summary: "I wrote about how and why I moved this blog to Netlify."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Yesterday, I moved my blog from GitHub Pages to Netlify. I wrote about the migration in my latest blog post, "[How and Why I Migrated My Blog From Github Pages to Netlify](/posts/how-and-why-i-migrated-my-blog-from-github-pages-to-netlify)".

--- a/content/dailies/13-11-22-writing-spree.md
+++ b/content/dailies/13-11-22-writing-spree.md
@@ -3,8 +3,6 @@ title: "#224 Writing Spree"
 date: 2022-11-13T22:58:29+05:30
 draft: false
 summary: "Write. Rewrite. Edit. Re-edit."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was working on a new article today. I have been trying to broaden the stuff I write about. This meant a lot of research and reading into topics I'm not an expert on.

--- a/content/dailies/13-2-22-varkala-and-punchakkari.md
+++ b/content/dailies/13-2-22-varkala-and-punchakkari.md
@@ -3,8 +3,6 @@ title: "#41 Varkala and Punchakkari"
 date: 2022-02-13T12:39:21+05:30
 draft: false
 summary: "Photos from the last three days at Varkala and Punchakkari."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 This song sets the tone perfectly.

--- a/content/dailies/13-3-22-everything-is-amazing-and-nobody-is-happy.md
+++ b/content/dailies/13-3-22-everything-is-amazing-and-nobody-is-happy.md
@@ -3,8 +3,6 @@ title: "#69 Everything Is Amazing and Nobody Is Happy"
 date: 2022-03-13T10:28:04+05:30
 draft: false
 summary: "Technological advancement makes our lives a lot easier. Or does it? Bonus: Photos from Meenkara Dam."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Concentration is key.

--- a/content/dailies/13-4-22-back-to-kerala.md
+++ b/content/dailies/13-4-22-back-to-kerala.md
@@ -3,8 +3,6 @@ title: "#100 Back to Kerala"
 date: 2022-04-13T21:34:37+05:30
 draft: false
 summary: "100 days? That's awesome!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It was very hard to go from three to four!

--- a/content/dailies/13-4-23-fossasia-day-1.md
+++ b/content/dailies/13-4-23-fossasia-day-1.md
@@ -3,8 +3,6 @@ title: "#260 FOSSASIA Summit Day 1"
 date: 2023-04-13T22:33:39+08:00
 draft: false
 summary: "FOSSASIA Summit started today!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The [FOSSASIA Summit](https://eventyay.com/e/7cfe0771) started today!

--- a/content/dailies/13-5-22-three-seasons-of-football.md
+++ b/content/dailies/13-5-22-three-seasons-of-football.md
@@ -3,8 +3,6 @@ title: "#129 Three Seasons of Football"
 date: 2022-05-13T19:55:08+05:30
 draft: false
 summary: "Watched three seasons of Friday Night Lights without knowing anything about American football."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I just watched three seasons of Friday Night Lights without knowing anything about American football.

--- a/content/dailies/13-6-22-test-ride.md
+++ b/content/dailies/13-6-22-test-ride.md
@@ -3,8 +3,6 @@ title: "#157 Test Ride"
 date: 2022-06-13T16:12:32+05:30
 draft: false
 summary: "Test drove Honda CB300R. I'm inclined to buy it. Bonus: Pictures from Chulliyar Dam."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I might buy the Honda CB300R.

--- a/content/dailies/13-7-22-playing-cricket-after-a-long-time.md
+++ b/content/dailies/13-7-22-playing-cricket-after-a-long-time.md
@@ -3,8 +3,6 @@ title: "#169 Playing Cricket After a Long Time"
 date: 2022-07-13T22:44:04+05:30
 draft: false
 summary: "We played cricket in our nearby turf and it was fun!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 We played cricket in our nearby turf and it was fun! Now I have to find people to play cricket with where I live. Too many football fans nowadays.

--- a/content/dailies/13-8-22-diagrams-in-my-new-blog.md
+++ b/content/dailies/13-8-22-diagrams-in-my-new-blog.md
@@ -3,8 +3,6 @@ title: "#182 Diagrams in My New Blog"
 date: 2022-08-13T22:00:32+05:30
 draft: false
 summary: "My new blog post will have diagrams. So, I added markdown to diagrams using Mermaid.js."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I spent my Saturday working on my new blog post. It's work-related, and I want to publish it on my blog.

--- a/content/dailies/14-1-22-deep-conversations.md
+++ b/content/dailies/14-1-22-deep-conversations.md
@@ -3,8 +3,6 @@ title: "#13 Deep Conversations"
 date: 2022-01-14T19:21:50+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have a good excuse for why I missed my writing schedule the past two days.

--- a/content/dailies/14-2-22-travel.md
+++ b/content/dailies/14-2-22-travel.md
@@ -3,8 +3,6 @@ title: "#42 Travel"
 date: 2022-02-14T08:56:05+05:30
 draft: false
 summary: "Too busy to write."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I missed writing here for two days.

--- a/content/dailies/14-2-23-hike-in-the-morning-work-in-the-evening.md
+++ b/content/dailies/14-2-23-hike-in-the-morning-work-in-the-evening.md
@@ -3,8 +3,6 @@ title: "#244 Hike in the Morning, Work in the Evening"
 date: 2023-02-14T17:45:39+08:00
 draft: false
 summary: "Hike at Windsor Nature Park and work at library@harbourfront."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I went for a long hike early this morning.

--- a/content/dailies/14-2-24-welcome-my-communist-brother.md
+++ b/content/dailies/14-2-24-welcome-my-communist-brother.md
@@ -3,8 +3,6 @@ title: '#276 "Welcome My Communist Brother!"'
 date: 2024-02-14T08:38:40+05:30
 draft: false
 summary: "Hello from Vietnam! Kind of."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I am back from a short vacation in Vietnam. The highlight of the trip was visiting the War Remnants Museum and Cu Chi Tunnels, which gave new perspectives on the Vietnam War.

--- a/content/dailies/14-3-22-stepping-down-from-a-maintainer.md
+++ b/content/dailies/14-3-22-stepping-down-from-a-maintainer.md
@@ -3,8 +3,6 @@ title: "#70 Stepping Down From a Maintainer"
 date: 2022-03-14T18:14:29+05:30
 draft: false
 summary: "I'm changing jobs and stepping down from a CNCF maintainer."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 What is _The Rock_ cooking?

--- a/content/dailies/14-4-22-piff-2022-is-on.md
+++ b/content/dailies/14-4-22-piff-2022-is-on.md
@@ -3,8 +3,6 @@ title: "#101 PIFF 2022 Is On!"
 date: 2022-04-14T19:12:25+05:30
 draft: false
 summary: "Organizing an international film festival every year is fun!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Tough one today.

--- a/content/dailies/14-4-23-fossasia-day-2.md
+++ b/content/dailies/14-4-23-fossasia-day-2.md
@@ -3,8 +3,6 @@ title: "#261 FOSSASIA Summit Day 2"
 date: 2023-04-14T16:37:47+08:00
 draft: false
 summary: "Day two means party time!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Day two had a lot of interesting talks.

--- a/content/dailies/14-5-22-all-about-the-bass.md
+++ b/content/dailies/14-5-22-all-about-the-bass.md
@@ -3,8 +3,6 @@ title: "#130 All About the Bass"
 date: 2022-05-14T19:51:37+05:30
 draft: false
 summary: "Bought two set of strings for my bass."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 A little known fact about me is that I play bass—the electric bass guitar.

--- a/content/dailies/14-6-22-busy-week-starts.md
+++ b/content/dailies/14-6-22-busy-week-starts.md
@@ -3,8 +3,6 @@ title: "#158 Busy Week Starts"
 date: 2022-06-14T07:56:41+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It is going to get busy this week. I have at least five open pull requests, and I'm making more. The film festival we are organizing kicks off this Friday. All my time away from work is spent there.

--- a/content/dailies/14-8-22-two-articles-a-day.md
+++ b/content/dailies/14-8-22-two-articles-a-day.md
@@ -3,8 +3,6 @@ title: "#183 Two Articles a Day"
 date: 2022-08-14T23:22:14+05:30
 draft: false
 summary: "Keeps socializing away."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been more active on my blog in the last four days than over the last four months combined.

--- a/content/dailies/14-9-22-open-source-summit-europe.md
+++ b/content/dailies/14-9-22-open-source-summit-europe.md
@@ -3,8 +3,6 @@ title: "#207 Open Source Summit Europe"
 date: 2022-09-14T10:40:52+01:00
 draft: false
 summary: "A bit last moment, but I made it here!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I managed to make it to Open Source Summit Europe in Dublin!

--- a/content/dailies/15-1-22-the-psychology-of-money.md
+++ b/content/dailies/15-1-22-the-psychology-of-money.md
@@ -3,8 +3,6 @@ title: "#14 The Psychology of Money"
 date: 2022-01-15T15:43:20+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I finished reading "[The Psychology of Money](https://www.goodreads.com/book/show/41881472-the-psychology-of-money)" by Morgan Housel today.

--- a/content/dailies/15-11-22-my-stance-on-cryptocurrency.md
+++ b/content/dailies/15-11-22-my-stance-on-cryptocurrency.md
@@ -3,8 +3,6 @@ title: "#225 My Stance on Cryptocurrency"
 date: 2022-11-15T11:46:37+05:30
 draft: false
 summary: "I have not voiced an opinion all along. But this week's article might change that."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I will publish a new article on Friday, which shows my stance on cryptocurrencies.

--- a/content/dailies/15-12-22-goodbye-google-analytics.md
+++ b/content/dailies/15-12-22-goodbye-google-analytics.md
@@ -3,8 +3,6 @@ title: "#232 Goodbye Google Analytics"
 date: 2022-12-15T20:27:21+05:30
 draft: false
 summary: "I'm moving away from using Google Analytics on this site."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I made the easy decision to switch the Plausible Analytics last week.

--- a/content/dailies/15-2-22-end-of-an-era.md
+++ b/content/dailies/15-2-22-end-of-an-era.md
@@ -3,8 +3,6 @@ title: "#43 End of an Era"
 date: 2022-02-15T18:20:27+05:30
 draft: false
 summary: "Goodbye People. Bonus: Photos and videos that will make me cry in a couple of days."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I left my campus yesterday after being here on and off for two years.

--- a/content/dailies/15-3-22-success.md
+++ b/content/dailies/15-3-22-success.md
@@ -3,8 +3,6 @@ title: "#71 Success"
 date: 2022-03-15T22:43:49+05:30
 draft: false
 summary: "Success is contagious. Bonus: Photos from Kava, Malampuzha."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Easy as a Tuesday morning.

--- a/content/dailies/15-4-22-waiting-for-visa.md
+++ b/content/dailies/15-4-22-waiting-for-visa.md
@@ -3,8 +3,6 @@ title: "#102 Waiting for Visa"
 date: 2022-04-15T19:53:22+05:30
 draft: false
 summary: "Shoulda, coulda, woulda got it in two."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Shoulda, coulda, woulda got it in two.

--- a/content/dailies/15-4-23-fossasia-day-3.md
+++ b/content/dailies/15-4-23-fossasia-day-3.md
@@ -3,8 +3,6 @@ title: "#262 FOSSASIA Summit Day 3"
 date: 2023-04-15T13:57:37+08:00
 draft: false
 summary: "I gave my talk today!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had to get up early to make it to my talk. Remind me to schedule my talks before the conference party next time!

--- a/content/dailies/15-5-22-missing-kubecon.md
+++ b/content/dailies/15-5-22-missing-kubecon.md
@@ -3,8 +3,6 @@ title: "#131 Missing Kubecon"
 date: 2022-05-15T20:03:04+05:30
 draft: false
 summary: "I missed my first in-person KubeCon."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had plans to go to KubeCon that was cancelled almost a month back. It didn't suck so much then but it is starting to suck now.

--- a/content/dailies/15-7-22-tour-de-alappuzha.md
+++ b/content/dailies/15-7-22-tour-de-alappuzha.md
@@ -3,8 +3,6 @@ title: "#170 Tour de Alappuzha"
 date: 2022-07-15T22:50:44+05:30
 draft: false
 summary: "Fun times in Alappuzha."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/15-7-22-tour-de-alappuzha/the-ride.jpeg#center" title="The ride" caption="Alappuzha - 15th July 2022" link="/images/15-7-22-tour-de-alappuzha/the-ride.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/15-7-24-nietzsche-on-a-long-drive.md
+++ b/content/dailies/15-7-24-nietzsche-on-a-long-drive.md
@@ -3,8 +3,6 @@ title: "#284 Nietzsche on a Long Drive"
 date: 2024-07-15T12:52:12+05:30
 draft: false
 summary: "Take me home, country roads."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 When I'm alone on a long drive, I almost always listen to podcasts or lectures I don't have time to listen to on regular days.

--- a/content/dailies/15-8-22-kubernetes-refresher.md
+++ b/content/dailies/15-8-22-kubernetes-refresher.md
@@ -3,8 +3,6 @@ title: "#184 Kubernetes Refresher"
 date: 2022-08-15T19:38:38+05:30
 draft: false
 summary: "Spent the day refreshing my Kubernetes knowledge."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been using Kubernetes since 2020. I built tooling around Kubernetes last year but lost my touch coming into 2022.

--- a/content/dailies/15-9-22-beers-whiskeys-talks-and-networking.md
+++ b/content/dailies/15-9-22-beers-whiskeys-talks-and-networking.md
@@ -3,8 +3,6 @@ title: "#208 Beers, Whiskeys, Talks, and Networking"
 date: 2022-09-15T16:46:50+01:00
 draft: false
 summary: "Photos from the past days in Dublin."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/15-9-22-beers-whiskeys-talks-and-networking/guinness-storehouse.jpeg#center" title="First thing to do in Ireland" caption="Guinness Storehouse, Dublin - 13th September 2022" link="/images/15-9-22-beers-whiskeys-talks-and-networking/guinness-storehouse.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/16-1-22-service-mesh-performance-and-asking-questions.md
+++ b/content/dailies/16-1-22-service-mesh-performance-and-asking-questions.md
@@ -3,8 +3,6 @@ title: "#15 Service Mesh Performance and Asking Questions"
 date: 2022-01-16T09:29:58+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have two upcoming talks in the next two weeks.

--- a/content/dailies/16-10-22-the-master-plan.md
+++ b/content/dailies/16-10-22-the-master-plan.md
@@ -3,8 +3,6 @@ title: "#215 The Master Plan"
 date: 2022-10-16T18:10:03+05:30
 draft: false
 summary: "Spending the weekend working on our town's future."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm spending the weekend working on our town's master plan. It's great seeing people from a small town come together with expert town planners to plan the town's future.

--- a/content/dailies/16-11-22-my-world-cup-predictions.md
+++ b/content/dailies/16-11-22-my-world-cup-predictions.md
@@ -3,8 +3,6 @@ title: "#226 My World Cup Predictions"
 date: 2022-11-16T13:09:35+05:30
 draft: false
 summary: "Based more on personal preferences than data. Let's see how this turns out."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had time to kill, so I made my predictions for the FIFA World Cup.

--- a/content/dailies/16-2-22-photographs-and-memories.md
+++ b/content/dailies/16-2-22-photographs-and-memories.md
@@ -3,8 +3,6 @@ title: "#44 Photographs and Memories"
 date: 2022-02-16T22:59:40+05:30
 draft: false
 summary: "Looking at old photos is one of the greatest joys in life."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I missed a couple of days of Wordle but my streak hasn't been broken apparently.

--- a/content/dailies/16-3-22-chill-days.md
+++ b/content/dailies/16-3-22-chill-days.md
@@ -3,8 +3,6 @@ title: "#72 Chill Days"
 date: 2022-03-16T19:01:43+05:30
 draft: false
 summary: "Taking time off before my new job."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 My old college roommate and I still play this everyday and share scores with each other.

--- a/content/dailies/16-4-22-simple-saturday.md
+++ b/content/dailies/16-4-22-simple-saturday.md
@@ -3,8 +3,6 @@ title: "#103 Simple Saturday"
 date: 2022-04-16T19:57:01+05:30
 draft: false
 summary: "Taking it slow. Photos!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 301 3/6

--- a/content/dailies/16-5-22-norwegian-wood.md
+++ b/content/dailies/16-5-22-norwegian-wood.md
@@ -3,8 +3,6 @@ title: "#132 Norwegian Wood"
 date: 2022-05-16T22:43:17+05:30
 draft: false
 summary: "Rainy days calls for nostalgia."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Back in 2020, when COVID-19 had just started, I used to read Murakami's novels on cold, gloomy, rainy days.

--- a/content/dailies/16-7-22-auf-wiedersehen.md
+++ b/content/dailies/16-7-22-auf-wiedersehen.md
@@ -3,8 +3,6 @@ title: "#171 Auf Wiedersehen"
 date: 2022-07-16T23:41:37+05:30
 draft: false
 summary: "Leaving these people. Again."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/16-7-22-auf-wiedersehen/bye.jpeg#center" title="Bye" caption="Trivandrum - 16th July 2022" link="/images/16-7-22-auf-wiedersehen/bye.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/16-8-22-i-look-into-headless-cms.md
+++ b/content/dailies/16-8-22-i-look-into-headless-cms.md
@@ -3,8 +3,6 @@ title: "#185 I Look Into Headless CMS"
 date: 2022-08-16T23:28:40+05:30
 draft: false
 summary: "I failed miserably."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I stumbled across headless CMS today. Seeing that some of the products had generous free tiers, I decided to try them out.

--- a/content/dailies/17-1-22-killing-time-and-unintended-consequences.md
+++ b/content/dailies/17-1-22-killing-time-and-unintended-consequences.md
@@ -3,8 +3,6 @@ title: "#16 Killing Time and Unintended Consequences"
 date: 2022-01-17T09:27:52+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I start off my "work day"—when I finish my morning routine and sit in front of my computer screen—by catching up on some light reading.

--- a/content/dailies/17-11-22-el-come-manzanas.md
+++ b/content/dailies/17-11-22-el-come-manzanas.md
@@ -3,8 +3,6 @@ title: "#227 Él Come Manzanas"
 date: 2022-11-17T17:31:50+05:30
 draft: false
 summary: "So, I started learning Spanish."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I signed up on Duolingo to learn Spanish. Spanish is spoken in many countries so it would be good to learn as I'm planning to travel a lot.

--- a/content/dailies/17-2-22-newsletter.md
+++ b/content/dailies/17-2-22-newsletter.md
@@ -3,8 +3,6 @@ title: "#45 Newsletter"
 date: 2022-02-17T17:29:09+05:30
 draft: false
 summary: "Launching my newsletter next week!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 No. No. Yes.

--- a/content/dailies/17-2-23-pause.md
+++ b/content/dailies/17-2-23-pause.md
@@ -3,8 +3,6 @@ title: "#245 Pause"
 date: 2023-02-17T16:04:09+08:00
 draft: false
 summary: "It is good to pause once in a while."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm writing this yet again from an airport. In fact, I'm writing this from the best airport in the world.

--- a/content/dailies/17-3-22-new-job-announcement.md
+++ b/content/dailies/17-3-22-new-job-announcement.md
@@ -3,8 +3,6 @@ title: "#73 New Job Announcement!"
 date: 2022-03-17T19:08:00+05:30
 draft: false
 summary: "It's official! I will be starting a new job on Monday!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I think I'm getting better at this.

--- a/content/dailies/17-4-22-busy-sunday.md
+++ b/content/dailies/17-4-22-busy-sunday.md
@@ -3,8 +3,6 @@ title: "#104 Busy Sunday"
 date: 2022-04-17T19:57:15+05:30
 draft: false
 summary: "I'm a workaholic."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 302 4/6

--- a/content/dailies/17-4-23-hello-from-another-airport.md
+++ b/content/dailies/17-4-23-hello-from-another-airport.md
@@ -3,8 +3,6 @@ title: "#263 Hello From Another Airport"
 date: 2023-04-17T15:54:25+05:30
 draft: false
 summary: "Continuing the theme."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm writing this after a heavy lunch at Chennai Airport.

--- a/content/dailies/17-5-22-tomb-raider.md
+++ b/content/dailies/17-5-22-tomb-raider.md
@@ -3,8 +3,6 @@ title: "#133 Tomb Raider"
 date: 2022-05-17T22:25:15+05:30
 draft: false
 summary: "I played a video game (and enjoyed it) after a long time."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I bought the first game in the Tomb Raider trilogy from 2013.

--- a/content/dailies/17-6-23-kcd-mumbai.md
+++ b/content/dailies/17-6-23-kcd-mumbai.md
@@ -3,8 +3,6 @@ title: "#266 KCD Mumbai"
 date: 2023-06-17T15:30:51+05:30
 draft: false
 summary: "I'm at Kubernetes Community Days Mumbai to talk about the Gateway API."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm back in Mumbai for Kubernetes Community Days.

--- a/content/dailies/17-8-22-failed-attempts.md
+++ b/content/dailies/17-8-22-failed-attempts.md
@@ -3,8 +3,6 @@ title: "#186 Failed Attempts"
 date: 2022-08-17T22:04:00+05:30
 draft: false
 summary: "Tried integrating Netlify CMS. It doesn't do what I want it to do."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had given up trying out CMS products yesterday. But after finding how easy it is to use Netlify's open source CMS, I decided to give it another try.

--- a/content/dailies/17-9-22-dublin.md
+++ b/content/dailies/17-9-22-dublin.md
@@ -3,8 +3,6 @@ title: "#209 Dublin"
 date: 2022-09-17T20:05:47+01:00
 draft: false
 summary: "Traveling around the city and the outskirts: 36,738 steps in a day with four hours to go."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/17-9-22-dublin/abbey-court.jpeg#center" title="I loved staying at Abbey Court" caption="Dublin - 16th September 2022" link="/images/17-9-22-dublin/abbey-court.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/18-1-22-the-psychology-of-money.md
+++ b/content/dailies/18-1-22-the-psychology-of-money.md
@@ -3,8 +3,6 @@ title: "#17 The Psychology of Money"
 date: 2022-01-18T19:53:18+05:30
 draft: false
 summary: 'I finished reading "The Psychology of Money".'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< blockquote author="Richard Feynman" link="https://en.wikiquote.org/wiki/Talk:Richard_Feynman#Imagine_how_much_harder_physics_would_be_if_electrons_had_feelings!" title="Speaking at a Caltech graduation ceremony" >}}

--- a/content/dailies/18-2-22-documentation-is-key.md
+++ b/content/dailies/18-2-22-documentation-is-key.md
@@ -3,8 +3,6 @@ title: "#46 Documentation is Key"
 date: 2022-02-18T18:19:39+05:30
 draft: false
 summary: "People can’t use what they don’t understand."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Too cool for par.

--- a/content/dailies/18-3-22-transitioning.md
+++ b/content/dailies/18-3-22-transitioning.md
@@ -3,8 +3,6 @@ title: "#74 Transitioning"
 date: 2022-03-18T17:56:22+05:30
 draft: false
 summary: "Transitioning into the new job and watching Pada."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 272 3/6

--- a/content/dailies/18-4-22-drive-to-survive.md
+++ b/content/dailies/18-4-22-drive-to-survive.md
@@ -3,8 +3,6 @@ title: "#105 Drive to Survive"
 date: 2022-04-18T19:26:57+05:30
 draft: false
 summary: "How fast is Lewis Hamilton?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 303 4/6

--- a/content/dailies/18-5-22-i-need-to-learn-how-to-stream.md
+++ b/content/dailies/18-5-22-i-need-to-learn-how-to-stream.md
@@ -3,8 +3,6 @@ title: "#134 I Need to Learn How to Stream"
 date: 2022-05-18T22:07:05+05:30
 draft: false
 summary: "Streamin away!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I got away with Zoom recordings for virtual talks at conferences these last few years.

--- a/content/dailies/18-7-24-ideas-that-stick.md
+++ b/content/dailies/18-7-24-ideas-that-stick.md
@@ -3,8 +3,6 @@ title: "#285 Ideas That Stick"
 date: 2024-07-18T17:31:57+05:30
 draft: false
 summary: "You are not you when you are hungry."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was listening to the [How I Write podcast episode with David Perell and Harry Dry](https://youtu.be/TUMjnmfsPeM?si=fFp3CwyI8SRRWW85), the great copywriter.

--- a/content/dailies/18-8-22-making-my-life-easier.md
+++ b/content/dailies/18-8-22-making-my-life-easier.md
@@ -3,8 +3,6 @@ title: "#187 Making My Life Easier"
 date: 2022-08-18T20:20:51+05:30
 draft: false
 summary: "I created a CLI in Go to create new posts."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I created a CLI in Go to create new posts.

--- a/content/dailies/19-1-22-the-minimalist-presenter.md
+++ b/content/dailies/19-1-22-the-minimalist-presenter.md
@@ -3,8 +3,6 @@ title: "#18 The Minimalist Presenter"
 date: 2022-01-19T19:51:26+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 _It's Wednesday my dudes!_

--- a/content/dailies/19-10-22-the-to-be-read-pile.md
+++ b/content/dailies/19-10-22-the-to-be-read-pile.md
@@ -3,8 +3,6 @@ title: '#216 The "To Be Read" Pile'
 date: 2022-10-19T20:58:26+05:30
 draft: false
 summary: "Catching up on my reading. I'm doing poorly."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I just finished reading all the open tabs on my email client. I have 38 tabs open on my browser.

--- a/content/dailies/19-2-22-whiplash-greatness-sacrifices-and-hard-work.md
+++ b/content/dailies/19-2-22-whiplash-greatness-sacrifices-and-hard-work.md
@@ -3,8 +3,6 @@ title: "#47 Whiplash, Greatness, Sacrifices and Hard Work"
 date: 2022-02-19T15:25:26+05:30
 draft: false
 summary: "I re-watched the movie Whiplash today. It is one of my favorite movies of all time."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Thought I had it at 4. Getting it at 5 was easy as I tried every remaining letter and eventually it spelled something meaningful and I got all green lights.

--- a/content/dailies/19-3-22-running-15-kms.md
+++ b/content/dailies/19-3-22-running-15-kms.md
@@ -3,8 +3,6 @@ title: "#75 Running 15 Kilometers"
 date: 2022-03-19T19:00:36+05:30
 draft: false
 summary: "I ran 15 kms today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Lucky guesses.

--- a/content/dailies/19-4-22-its-too-hard-twss.md
+++ b/content/dailies/19-4-22-its-too-hard-twss.md
@@ -3,8 +3,6 @@ title: "#106 It's Too Hard! (TWSS)"
 date: 2022-04-19T21:31:27+05:30
 draft: false
 summary: "That's what she said."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Today's Wordle was so hard, I cheated.

--- a/content/dailies/19-5-22-rise-of-the-tomb-raider.md
+++ b/content/dailies/19-5-22-rise-of-the-tomb-raider.md
@@ -3,8 +3,6 @@ title: "#135 Rise of the Tomb Raider"
 date: 2022-05-19T19:58:35+05:30
 draft: false
 summary: "I finished the first one. Moving on to the next."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 As I was writing this, a notification popped up on my screen saying that "Rise of the Tomb Raider" had finished downloading.

--- a/content/dailies/19-6-23-top-things-to-do-in-malaysia.md
+++ b/content/dailies/19-6-23-top-things-to-do-in-malaysia.md
@@ -3,8 +3,6 @@ title: "#267 Top Things to Do in Malaysia"
 date: 2023-06-19T19:25:42+05:30
 draft: false
 summary: "I'm sorting through the mess to plan my travels for next month."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm finally able to plan my travels for next month.

--- a/content/dailies/19-8-22-reliability.md
+++ b/content/dailies/19-8-22-reliability.md
@@ -3,8 +3,6 @@ title: "#188 Reliability"
 date: 2022-08-19T22:35:58+05:30
 draft: false
 summary: "New post published today. Friday is new blog day now."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I completed my goal to publish every Friday. It has only been two Fridays, but it is still something.

--- a/content/dailies/19-8-23-what-i-have-been-up-to.md
+++ b/content/dailies/19-8-23-what-i-have-been-up-to.md
@@ -3,8 +3,6 @@ title: "#268 What I Have Been Up To"
 date: 2023-08-19T13:02:08+05:30
 draft: false
 summary: "Long time no see."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It has been two months since I wrote one of these! It is the longest I have not written daily logs since I started this almost two years ago. But sometimes, life gets in the way, and you are too busy to just sit down and write your thoughts.

--- a/content/dailies/2-1-22-blocked-by-blockchains.md
+++ b/content/dailies/2-1-22-blocked-by-blockchains.md
@@ -3,8 +3,6 @@ title: "#3 Blocked by Blockchains"
 date: 2022-01-03T11:58:47+05:30
 draft: false
 summary: "Learning about Blockchain, Crypto and Web3."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I can't go a day without seeing "10 Free Resources to Learn Web3" Tweets on my feed.

--- a/content/dailies/2-2-22-wordle-and-building-side-projects.md
+++ b/content/dailies/2-2-22-wordle-and-building-side-projects.md
@@ -3,8 +3,6 @@ title: "#32 Wordle and Building Side Projects"
 date: 2022-02-02T16:33:05+05:30
 draft: false
 summary: "Wordle and what I'm doing about my side projects."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Oh yea!

--- a/content/dailies/2-2-23-index-and-chill.md
+++ b/content/dailies/2-2-23-index-and-chill.md
@@ -3,8 +3,6 @@ title: "#237 Index and Chill"
 date: 2023-02-02T18:53:03+05:30
 draft: false
 summary: "No, I don't want to day trade and get rich."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I didn't have any idea of how finances worked. I think I still don't.

--- a/content/dailies/2-3-22-parks-and-recs-is-the-best-tv-show-ever.md
+++ b/content/dailies/2-3-22-parks-and-recs-is-the-best-tv-show-ever.md
@@ -3,8 +3,6 @@ title: "#58 Parks and Recs is the Best TV Show Ever"
 date: 2022-03-02T09:56:43+05:30
 draft: false
 summary: "Li'l Sebastian is probably the best minor character in the whole show."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/2-4-22-getting-new-equipment-and-xkcd.md
+++ b/content/dailies/2-4-22-getting-new-equipment-and-xkcd.md
@@ -3,8 +3,6 @@ title: "#89 Getting New Equipment and XKCD"
 date: 2022-04-02T12:26:44+05:30
 draft: false
 summary: "I'm getting new equipment."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 😎

--- a/content/dailies/2-4-23-blog-binging.md
+++ b/content/dailies/2-4-23-blog-binging.md
@@ -3,8 +3,6 @@ title: "#254 Blog Binging"
 date: 2023-04-02T23:42:04+05:30
 draft: false
 summary: "IDK if this is good or bad."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Every so often, I stumble across fascinating personal blogs of engineers.

--- a/content/dailies/2-5-22-working-for-fun.md
+++ b/content/dailies/2-5-22-working-for-fun.md
@@ -3,8 +3,6 @@ title: "#118 Working for Fun"
 date: 2022-05-02T14:40:59+05:30
 draft: false
 summary: "A large percentage of your life should be filled with things you absolutely love to do."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Words are meaningless.

--- a/content/dailies/2-5-23-tattoos-on-my-internet.md
+++ b/content/dailies/2-5-23-tattoos-on-my-internet.md
@@ -3,8 +3,6 @@ title: "#264 Tattoos on My Internet"
 date: 2023-05-02T17:30:47+05:30
 draft: false
 summary: "Why am I at an airport again?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It has been a while. I was super busy traveling for work and personal reasons and couldn't find time to write this.

--- a/content/dailies/2-6-22-npcb.md
+++ b/content/dailies/2-6-22-npcb.md
@@ -3,8 +3,6 @@ title: "#146 NPCB"
 date: 2022-06-02T17:51:47+05:30
 draft: false
 summary: "Rewatching NPCB for the millionth time."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Every year, there is a time when I feel the urge to rewatch Neelakasham Pachakadal Chuvanna Bhoomi.

--- a/content/dailies/2-6-24-before-apachecon.md
+++ b/content/dailies/2-6-24-before-apachecon.md
@@ -3,8 +3,6 @@ title: "#282 Before ApacheCon"
 date: 2024-06-02T19:23:12+02:00
 draft: false
 summary: "I'm in Europe for ApacheCon!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm in Bratislava, Slovakia, for ~~ApacheCon~~ [Community Over Code Europe](https://eu.communityovercode.org/).

--- a/content/dailies/2-9-22-diversity-equity-and-inclusion-in-open-source.md
+++ b/content/dailies/2-9-22-diversity-equity-and-inclusion-in-open-source.md
@@ -3,8 +3,6 @@ title: "#200 Diversity, Equity, and Inclusion in Open Source"
 date: 2022-09-02T20:41:24+05:30
 draft: false
 summary: '"I can''t believe I''ve been writing this for 200 days", preparing for conferences, and reading through Linux Foundation''s DEI report.'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 200 daily logs. That's a lot of words.

--- a/content/dailies/20-1-22-covid-19-uncertainties.md
+++ b/content/dailies/20-1-22-covid-19-uncertainties.md
@@ -3,8 +3,6 @@ title: "#19 COVID 19 Uncertainties"
 date: 2022-01-20T18:37:14+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The Coronavirus Omicron variant is hitting hard in India and I'm in its epicenter in Trivandrum.

--- a/content/dailies/20-2-22-selling-yourself.md
+++ b/content/dailies/20-2-22-selling-yourself.md
@@ -3,8 +3,6 @@ title: "#48 Selling Yourself"
 date: 2022-02-20T21:19:29+05:30
 draft: false
 summary: "Do you have an MBA?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 How good was 2003?

--- a/content/dailies/20-3-22-isl-final.md
+++ b/content/dailies/20-3-22-isl-final.md
@@ -3,8 +3,6 @@ title: "#76 ISL Final"
 date: 2022-03-20T11:01:17+05:30
 draft: false
 summary: "ISL final watch party! Bonus: Pictures from Malampuzha Dam."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I forgot to play Wordle today and I lost my 52 day streak.

--- a/content/dailies/20-4-22-i-cant-afford-formula-1.md
+++ b/content/dailies/20-4-22-i-cant-afford-formula-1.md
@@ -3,8 +3,6 @@ title: "#107 I Can't Afford Formula 1"
 date: 2022-04-20T22:09:08+05:30
 draft: false
 summary: "I might very well have an opportunity to watch a Grand Prix but it costs way too much."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Where did the car go?

--- a/content/dailies/20-8-22-incentivization.md
+++ b/content/dailies/20-8-22-incentivization.md
@@ -3,8 +3,6 @@ title: "#189 Incentivization"
 date: 2022-08-20T22:39:32+05:30
 draft: false
 summary: "The line between incentivization and gamification of open source contributions is blurry."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm writing about how incentivizing open source contributions can quickly turn into gamification of the system. This will be featured in [my newsletter](/subscribe) this coming Friday.

--- a/content/dailies/20-8-23-what-i-have-been-up-to.md
+++ b/content/dailies/20-8-23-what-i-have-been-up-to.md
@@ -3,8 +3,6 @@ title: "#269 What I Have Been Up To"
 date: 2023-08-20T13:18:41+05:30
 draft: false
 summary: "Long time no see."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 There are many more photos, and adding them to a single post will be difficult. So I'm continuing what I have been up to in the past month here.

--- a/content/dailies/21-1-22-always-having-a-book-to-read.md
+++ b/content/dailies/21-1-22-always-having-a-book-to-read.md
@@ -3,8 +3,6 @@ title: "#20 Always Having a Book to Read"
 date: 2022-01-21T07:28:34+05:30
 draft: false
 summary: "Always having a book to read helped me from falling down YouTube rabbit holes."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I always have a book to read. Even if I haven't read it in months, I am _technically still reading_ the book.

--- a/content/dailies/21-2-22-knowing-the-game-you-are-playing.md
+++ b/content/dailies/21-2-22-knowing-the-game-you-are-playing.md
@@ -3,8 +3,6 @@ title: "#49 Knowing the Game You Are Playing"
 date: 2022-02-21T18:20:31+05:30
 draft: false
 summary: "You play a different game than everyone else. Understanding that is the first step."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It's the easy words that get you.

--- a/content/dailies/21-2-23-back-in-kerala.md
+++ b/content/dailies/21-2-23-back-in-kerala.md
@@ -3,8 +3,6 @@ title: "#246 Back in Kerala"
 date: 2023-02-21T10:43:01+05:30
 draft: false
 summary: "Doing Kerala things."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm back in Kerala after more than a week. I did "Kerala things" over the weekend and did not rest after the week-long travel.

--- a/content/dailies/21-2-24-hard-rights.md
+++ b/content/dailies/21-2-24-hard-rights.md
@@ -3,8 +3,6 @@ title: "#277 Hard Rights"
 date: 2024-02-21T18:20:51+05:30
 draft: false
 summary: "Handbrake life turns are hard for many reasons."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I am surprised by how my thinking around pursuits, professions, and life goals evolved.

--- a/content/dailies/21-3-22-day-1-at-new-job.md
+++ b/content/dailies/21-3-22-day-1-at-new-job.md
@@ -3,8 +3,6 @@ title: "#77 Day 1 at New Job"
 date: 2022-03-21T11:20:33+05:30
 draft: false
 summary: "I start at API7.ai today!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I still can't believe [I missed Wordle yesterday](../20-3-22-isl-final).

--- a/content/dailies/21-4-22-one-month-at-new-job.md
+++ b/content/dailies/21-4-22-one-month-at-new-job.md
@@ -3,8 +3,6 @@ title: "#108 One Month at New Job"
 date: 2022-04-21T19:29:38+05:30
 draft: false
 summary: "One month flew by! Made some significant contributions. Bonus: Photo from my friend's marriage!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I didn't play Wordle today and I broke my streak for the second time.

--- a/content/dailies/21-8-23-what-i-have-been-up-to.md
+++ b/content/dailies/21-8-23-what-i-have-been-up-to.md
@@ -3,8 +3,6 @@ title: "#270 What I Have Been Up To"
 date: 2023-08-21T19:31:35+05:30
 draft: false
 summary: "Long time no see."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been sharing photos here in the past few days, but like I said the other day, I have been up to a [lot of stuff](/dailies/19-8-23-what-i-have-been-up-to/).

--- a/content/dailies/22-1-22-what-i-talk-about-when-i-talk-about-haruki-murakami.md
+++ b/content/dailies/22-1-22-what-i-talk-about-when-i-talk-about-haruki-murakami.md
@@ -3,8 +3,6 @@ title: "#21 What I Talk About When I Talk About Haruki Murakami"
 date: 2022-01-22T19:05:08+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I finished reading "[The Defining Decade](https://www.goodreads.com/book/show/40603783-the-defining-decade)" by Meg Jay.

--- a/content/dailies/22-11-22-quiet-passions.md
+++ b/content/dailies/22-11-22-quiet-passions.md
@@ -3,8 +3,6 @@ title: "#228 Quiet Passions"
 date: 2022-11-22T20:24:06+05:30
 draft: false
 summary: "How internet brought quite passions to life."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The internet has enabled a lot of people with different skills and interests from their immediate peers to find like-minded people.

--- a/content/dailies/22-2-22-currently-reading.md
+++ b/content/dailies/22-2-22-currently-reading.md
@@ -3,8 +3,6 @@ title: "#50 Currently Reading"
 date: 2022-02-22T16:38:16+05:30
 draft: false
 summary: "50 days of writing! But what am I reading now?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Will we ever get tired of this game?

--- a/content/dailies/22-2-23-virtue-signaling.md
+++ b/content/dailies/22-2-23-virtue-signaling.md
@@ -3,8 +3,6 @@ title: "#247 Virtue Signaling"
 date: 2023-02-22T11:37:25+05:30
 draft: false
 summary: "Virtue signaling is a global problem."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Virtue signaling is a global problem.

--- a/content/dailies/22-3-22-day-2-at-new-job.md
+++ b/content/dailies/22-3-22-day-2-at-new-job.md
@@ -3,8 +3,6 @@ title: "#78 Day 2 at New Job"
 date: 2022-03-22T19:34:11+05:30
 draft: false
 summary: "Finding my bearings."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Will I ever stop playing this?

--- a/content/dailies/22-4-22-cancelling-kubecon-plans.md
+++ b/content/dailies/22-4-22-cancelling-kubecon-plans.md
@@ -3,8 +3,6 @@ title: "#109 Cancelling KubeCon Plans"
 date: 2022-04-22T13:44:40+05:30
 draft: false
 summary: "I would not be traveling to KubeCon in Valencia. It sucks. See you next year!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I can miss days if I come back with a bang.

--- a/content/dailies/22-7-22-tour-de-veezhumala.md
+++ b/content/dailies/22-7-22-tour-de-veezhumala.md
@@ -3,8 +3,6 @@ title: "#172 Tour De Veezhumala"
 date: 2022-07-22T22:39:39+05:30
 draft: false
 summary: "Intense trek to reach the top of Veezhumala."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/22-7-22-tour-de-veezhumala/people.jpeg#center" title="People" caption="Veezhumala - 22nd July 2022" link="/images/22-7-22-tour-de-veezhumala/people.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/22-7-24-piastris-maiden-win.md
+++ b/content/dailies/22-7-24-piastris-maiden-win.md
@@ -3,8 +3,6 @@ title: "#286 Piastri's Maiden Win"
 date: 2024-07-22T20:13:50+05:30
 draft: false
 summary: "What did I just witness?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was out the other day and missed the Hungarian Grand Prix. But after waking up to all the Twitter drama about Max Verstappen just sending it out of nowhere and McLaren seeming to do everything in their power to make what should be their best season in a very long time difficult, I had no choice but to watch the whole race replay.

--- a/content/dailies/22-8-22-im-writing-this-from-a-train.md
+++ b/content/dailies/22-8-22-im-writing-this-from-a-train.md
@@ -3,8 +3,6 @@ title: "#190 I'm Writing This From a Train"
 date: 2022-08-22T16:20:26+05:30
 draft: false
 summary: "Work from train."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm on a train as I'm writing this.

--- a/content/dailies/22-8-23-you-havent-changed-at-all.md
+++ b/content/dailies/22-8-23-you-havent-changed-at-all.md
@@ -3,8 +3,6 @@ title: "#271 You Haven't Changed at All"
 date: 2023-08-22T19:14:37+05:30
 draft: false
 summary: 'Why do you always hear, "You haven''t changed at all!"?'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had this hypothesis that people say, "You haven't changed at all" when meeting after a long time because people behave differently around different people.

--- a/content/dailies/23-1-22-personal-monopolies.md
+++ b/content/dailies/23-1-22-personal-monopolies.md
@@ -3,8 +3,6 @@ title: "#22 Personal Monopolies"
 date: 2022-01-23T12:35:35+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I want to be _the only person that does what I do_.

--- a/content/dailies/23-10-24-a-worthy-cms.md
+++ b/content/dailies/23-10-24-a-worthy-cms.md
@@ -3,9 +3,6 @@ title: "#288 A Worthy CMS"
 date: 2024-10-23T22:01:01+05:30
 draft: false
 summary: I FINALLY found a CMS I can work with (without driving myself mad).
-tags:
-  - daily log
-categories: Daily Dose of Pottekkat
 fmContentType: Daily
 ---
 

--- a/content/dailies/23-2-22-fighting-a-different-fight.md
+++ b/content/dailies/23-2-22-fighting-a-different-fight.md
@@ -3,8 +3,6 @@ title: "#51 Fighting a Different Fight"
 date: 2022-02-23T14:31:20+05:30
 draft: false
 summary: "Is it healthy to rebel everything that came before?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Words I don't know are not that hard to guess.

--- a/content/dailies/23-3-22-what-am-i-working-on.md
+++ b/content/dailies/23-3-22-what-am-i-working-on.md
@@ -3,8 +3,6 @@ title: "#79 What Am I Working On?"
 date: 2022-03-23T19:27:42+05:30
 draft: false
 summary: "I try to articulate what I'm working on."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 On some days, I have to really think.

--- a/content/dailies/23-5-22-kasaragod.md
+++ b/content/dailies/23-5-22-kasaragod.md
@@ -3,8 +3,6 @@ title: "#136 Kasaragod"
 date: 2022-05-23T11:27:54+05:30
 draft: false
 summary: "Traveled to Kasaragod over the weekend. Bonus: Photos!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I went to Kasaragod to attend a marriage this weekend.

--- a/content/dailies/23-8-22-open-source-summit-latin-america.md
+++ b/content/dailies/23-8-22-open-source-summit-latin-america.md
@@ -3,8 +3,6 @@ title: "#191 Open Source Summit Latin America"
 date: 2022-08-23T22:20:05+05:30
 draft: false
 summary: "I'm live!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I spoke at Open Source Latin America a couple of hours ago. It was fun, and I had a few questions during the talk and at the end. People seemed to like it.

--- a/content/dailies/23-8-23-people-are-awesome.md
+++ b/content/dailies/23-8-23-people-are-awesome.md
@@ -3,8 +3,6 @@ title: "#272 People Are Awesome"
 date: 2023-08-23T17:48:49+05:30
 draft: false
 summary: "ISRO just landed a spacecraft on the frickin moon."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 What a great day to be alive and witness ISRO landing Chandrayaan-3 on the moon. Seeing the joy and sense of achievement of the scientists behind the project was something. I hope this inspires a new generation of engineers, scientists, and spacefarers. _People are awesome._

--- a/content/dailies/23-9-22-how-many-flights-is-too-many-flights.md
+++ b/content/dailies/23-9-22-how-many-flights-is-too-many-flights.md
@@ -3,8 +3,6 @@ title: "#210 How Many Flights Is Too Many Flights?"
 date: 2022-09-23T22:03:56+05:30
 draft: false
 summary: "I was in too many airports this week. Bonus: Photos from COCON."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It has been a busy and tiring week. I came back from Dublin on Tuesday and only came to my senses Wednesday evening. Then I prepared for my talk for Friday (today) and left Thursday afternoon again to reach the conference.

--- a/content/dailies/23-9-24-london-is-londoning.md
+++ b/content/dailies/23-9-24-london-is-londoning.md
@@ -3,8 +3,6 @@ title: "#287 London is Londoning"
 date: 2024-09-23T17:38:51+05:30
 draft: false
 summary: "Highlights from my recent London trip."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I don't know how else to put it, but _London is Londoning_. The city looks precisely as painted in books and movies. It gave me a sense of familiarity even though it was my first visit.

--- a/content/dailies/24-1-22-kindling-productivity.md
+++ b/content/dailies/24-1-22-kindling-productivity.md
@@ -3,8 +3,6 @@ title: "#23 Kindling Productivity"
 date: 2022-01-24T23:49:09+05:30
 draft: false
 summary: "I have been reading more ever since I started using my Kindle again."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been reading more ever since I started using my Kindle again.

--- a/content/dailies/24-10-22-task-switching-and-efficiency.md
+++ b/content/dailies/24-10-22-task-switching-and-efficiency.md
@@ -3,8 +3,6 @@ title: "#217 Task Switching and Efficiency"
 date: 2022-10-24T18:53:15+05:30
 draft: false
 summary: "Switching tasks can unlock a different kind of efficiency."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 One of the perks of my job is there are always entirely different categories of tasks I need to do.

--- a/content/dailies/24-10-24-naive-neo-marxists-and-intrinsic-human-behavior.md
+++ b/content/dailies/24-10-24-naive-neo-marxists-and-intrinsic-human-behavior.md
@@ -3,9 +3,6 @@ title: "#289 Naive Neo-Marxists and Intrinsic Human Behavior"
 date: 2024-10-24T21:50:55+05:30
 draft: false
 summary: My beef against Marxists and Marxism has grown since I started learning economics.
-tags:
-  - daily log
-categories: Daily Dose of Pottekkat
 fmContentType: Daily
 ---
 

--- a/content/dailies/24-2-22-what-good-is-saved-time-if-nobody-uses-it.md
+++ b/content/dailies/24-2-22-what-good-is-saved-time-if-nobody-uses-it.md
@@ -3,8 +3,6 @@ title: "#52 What Good Is Saved Time if Nobody Uses It?"
 date: 2022-02-24T8:54:29+05:30
 draft: false
 summary: "We are obsessed with saving time."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I thought I had it at two. Could I _[be](https://memegenerator.net/img/instances/59277106/could-i-be-any-more-wrong.jpg)_ any more wrong?

--- a/content/dailies/24-3-22-back-to-content-creation.md
+++ b/content/dailies/24-3-22-back-to-content-creation.md
@@ -3,8 +3,6 @@ title: "#80 Back to Content Creation"
 date: 2022-03-24T10:41:14+05:30
 draft: false
 summary: "I start writing again!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 😎

--- a/content/dailies/24-3-23-report-cards-prompts-and-compilers.md
+++ b/content/dailies/24-3-23-report-cards-prompts-and-compilers.md
@@ -3,8 +3,6 @@ title: "#249 Report Cards, Prompts, and Compilers"
 date: 2023-03-24T18:02:59+05:30
 draft: false
 summary: "Have you learned to write prompts yet?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Have you learned to write ~~code~~ prompts yet?

--- a/content/dailies/24-4-22-too-busy-to-write.md
+++ b/content/dailies/24-4-22-too-busy-to-write.md
@@ -3,8 +3,6 @@ title: "#110 Too Busy to Write?"
 date: 2022-04-24T19:44:49+05:30
 draft: false
 summary: "I'm too busy to write. Even to play Wordle!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had a busy weekend. I was too busy to even play Wordle. There goes my streak.

--- a/content/dailies/24-5-22-in-sickness-and-health.md
+++ b/content/dailies/24-5-22-in-sickness-and-health.md
@@ -3,8 +3,6 @@ title: "#137 In Sickness and Health"
 date: 2022-05-24T18:18:54+05:30
 draft: false
 summary: "Sick today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was sick today after a long time.

--- a/content/dailies/24-8-22-more-content.md
+++ b/content/dailies/24-8-22-more-content.md
@@ -3,8 +3,6 @@ title: "#192 More Content"
 date: 2022-08-24T19:41:18+05:30
 draft: false
 summary: "Upping my content game."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I invested in some tools to level up my content on the internet.

--- a/content/dailies/24-8-23-the-newsletter-is-back.md
+++ b/content/dailies/24-8-23-the-newsletter-is-back.md
@@ -3,8 +3,6 @@ title: "#273 The Newsletter Is Back"
 date: 2023-08-24T23:08:47+05:30
 draft: false
 summary: "I am back writing my newsletter after a three-month hiatus."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I sent out the last issue of my newsletter in May. It has been over three months since I wrote one of those for reasons you will find in the newsletter ([subscribe now!](/subscribe/)).

--- a/content/dailies/25-1-22-silicon-valley-gets-software-engineers.md
+++ b/content/dailies/25-1-22-silicon-valley-gets-software-engineers.md
@@ -3,8 +3,6 @@ title: '#24 Silicon Valley "Gets" Software Engineers'
 date: 2022-01-25T12:20:40+05:30
 draft: false
 summary: ""
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 My vocabulary of five letter words is improving—thanks to Wordle.

--- a/content/dailies/25-1-23-traveling-for-work.md
+++ b/content/dailies/25-1-23-traveling-for-work.md
@@ -3,8 +3,6 @@ title: "#235 Traveling for Work"
 date: 2023-01-25T20:18:27+05:30
 draft: false
 summary: "Starting my travels for the year."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have started my "work travels" for the year.

--- a/content/dailies/25-10-24-tutorials.md
+++ b/content/dailies/25-10-24-tutorials.md
@@ -4,9 +4,6 @@ date: 2024-10-25T22:20:52+05:30
 draft: false
 summary: |
   Writing tutorials isn't always fun, but it is necessary and helpful.
-tags:
-  - daily log
-categories: Daily Dose of Pottekkat
 fmContentType: Daily
 ---
 

--- a/content/dailies/25-2-22-never-have-i-ever-been-published-in-print-media.md
+++ b/content/dailies/25-2-22-never-have-i-ever-been-published-in-print-media.md
@@ -3,8 +3,6 @@ title: "#53 Never Have I Ever Been Published in Print Media"
 date: 2022-02-25T14:23:24+05:30
 draft: false
 summary: "My article is being published in a print magazine!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/25-3-22-in-a-users-shoes.md
+++ b/content/dailies/25-3-22-in-a-users-shoes.md
@@ -3,8 +3,6 @@ title: "#81 In a User's Shoes"
 date: 2022-03-25T19:28:39+05:30
 draft: false
 summary: "Thinking from a user's perspective to make a project better."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Took too long. I'm loosing my knack.

--- a/content/dailies/25-3-23-from-bahrain.md
+++ b/content/dailies/25-3-23-from-bahrain.md
@@ -3,8 +3,6 @@ title: "#250 From Bahrain"
 date: 2023-03-25T14:57:33+05:30
 draft: false
 summary: "Photos from the Bahrain Grand Prix."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I went to the Bahrain Grand Prix earlier this month.

--- a/content/dailies/25-4-22-getting-started.md
+++ b/content/dailies/25-4-22-getting-started.md
@@ -3,8 +3,6 @@ title: "#111 Getting Started"
 date: 2022-04-25T19:41:15+05:30
 draft: false
 summary: 'Refactoring the "Getting started" guide.'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Streak is back at 1.

--- a/content/dailies/25-5-22-sick-day.md
+++ b/content/dailies/25-5-22-sick-day.md
@@ -3,8 +3,6 @@ title: "#138 Sick Day"
 date: 2022-05-25T21:28:20+05:30
 draft: false
 summary: "In sickness and health 2.0."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I took a sick day from work today. Rested all morning and started to feel better by evening.

--- a/content/dailies/25-6-22-ten-days-of-festivities.md
+++ b/content/dailies/25-6-22-ten-days-of-festivities.md
@@ -3,8 +3,6 @@ title: "#159 Ten Days of Festivities"
 date: 2022-06-25T18:39:13+05:30
 draft: false
 summary: "It's been a long week, without you my friend. Bonus: Photos from PIFF 2022!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Whew!

--- a/content/dailies/25-8-22-writing-regularly.md
+++ b/content/dailies/25-8-22-writing-regularly.md
@@ -3,8 +3,6 @@ title: "#193 Writing Regularly"
 date: 2022-08-25T21:01:41+05:30
 draft: false
 summary: "Every successful blogger I follow says that the key to their success is writing regularly."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm getting back on my continuous writing schedule. I fell off the tracks a couple of months back, but now I feel I'm back 100%.

--- a/content/dailies/25-8-23-open-access-and-open-source.md
+++ b/content/dailies/25-8-23-open-access-and-open-source.md
@@ -3,8 +3,6 @@ title: "#274 Open Access and Open Source"
 date: 2023-08-25T18:49:36+05:30
 draft: false
 summary: "Can the open access movement learn from open source?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been thinking about the Open Access movement in scientific publishing recently. Basically, most scientific research, funded mostly by public money, is behind paywalls.

--- a/content/dailies/26-1-22-sanju-basil-and-risks.md
+++ b/content/dailies/26-1-22-sanju-basil-and-risks.md
@@ -3,8 +3,6 @@ title: "#25 Sanju, Basil and Risks"
 date: 2022-01-26T19:16:55+05:30
 draft: false
 summary: 'How good is the "Basil meets Sanju" interview?'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 How good is the "[Basil meets Sanju](https://youtu.be/r3y6VLsqpYw)" interview?

--- a/content/dailies/26-10-22-younger-generation-might-not-be-super-techy.md
+++ b/content/dailies/26-10-22-younger-generation-might-not-be-super-techy.md
@@ -3,8 +3,6 @@ title: '#218 The Younger Generation Might Not Be Super "Techy"'
 date: 2022-10-26T14:20:56+05:30
 draft: false
 summary: "Hot take: Being able to use technology does not necessarily mean you are good at building it."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 People born after the mid-2000s grew up in a world with a boom in end-user technology.

--- a/content/dailies/26-2-22-come-here.md
+++ b/content/dailies/26-2-22-come-here.md
@@ -3,8 +3,6 @@ title: "#54 Come Here"
 date: 2022-02-26T09:56:19+05:30
 draft: false
 summary: "Quick update and a song I like."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/26-3-22-first-day-off.md
+++ b/content/dailies/26-3-22-first-day-off.md
@@ -3,8 +3,6 @@ title: "#82 First Day Off"
 date: 2022-03-26T08:30:39+05:30
 draft: false
 summary: "First day off since I started my new job."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I still send my scores to my old grad school roommate.

--- a/content/dailies/26-4-22-eliciting-conference-talks-from-users.md
+++ b/content/dailies/26-4-22-eliciting-conference-talks-from-users.md
@@ -3,8 +3,6 @@ title: "#112 Eliciting Conference Talks From Users"
 date: 2022-04-26T21:53:21+05:30
 draft: false
 summary: "What should I talk about next?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Bella ciao!

--- a/content/dailies/26-5-22-prepping-for-a-talk.md
+++ b/content/dailies/26-5-22-prepping-for-a-talk.md
@@ -3,8 +3,6 @@ title: "#139 Prepping for a Talk"
 date: 2022-05-26T11:44:23+05:30
 draft: false
 summary: "First timer talks are always a lot of work."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have to finish recording a talk by Sunday. It's my first talk about API gateways, and hopefully, it will be much easier the second time.

--- a/content/dailies/26-6-22-road-trip-to-valparai.md
+++ b/content/dailies/26-6-22-road-trip-to-valparai.md
@@ -3,8 +3,6 @@ title: "#160 Road Trip to Valparai"
 date: 2022-06-26T21:13:20+05:30
 draft: false
 summary: "We went on a road trip."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 We went on a road trip. Photos coming soon!

--- a/content/dailies/26-8-22-brain-drain-personal-brand-newsletter-v20.md
+++ b/content/dailies/26-8-22-brain-drain-personal-brand-newsletter-v20.md
@@ -3,8 +3,6 @@ title: "#194 Brain Drain, Personal Brand, Newsletter v2.0"
 date: 2022-08-26T22:14:59+05:30
 draft: false
 summary: "Supply and demand."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I live in my hometown, and I work remotely. I'm paid well by my Hong Kong-based company, and I live a comfortable life.

--- a/content/dailies/27-1-22-day-in-the-life-of.md
+++ b/content/dailies/27-1-22-day-in-the-life-of.md
@@ -3,8 +3,6 @@ title: "#26 Day in the Life Of"
 date: 2022-01-27T16:55:11+05:30
 draft: false
 summary: "Nothing much. Just a daily update."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Boom!

--- a/content/dailies/27-10-22-checo-wins-mexico.md
+++ b/content/dailies/27-10-22-checo-wins-mexico.md
@@ -3,8 +3,6 @@ title: "#219 Checo Wins Mexico"
 date: 2022-10-27T21:53:33+05:30
 draft: false
 summary: "Mexico GP weekend is here and everyone wants Checo to win."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It is race weekend in Mexico, and we all want Checo Perez to win.

--- a/content/dailies/27-11-22-a-day-of-fast-bowling.md
+++ b/content/dailies/27-11-22-a-day-of-fast-bowling.md
@@ -3,8 +3,6 @@ title: "#229 A Day of Fast Bowling"
 date: 2022-11-27T20:40:44+05:30
 draft: false
 summary: "Don't play sports without training."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 The last time I played in a cricket tournament was in 2019. Even though I like playing, I haven't been able to in the past years.

--- a/content/dailies/27-2-22-authenticity.md
+++ b/content/dailies/27-2-22-authenticity.md
@@ -3,8 +3,6 @@ title: "#55 Authenticity"
 date: 2022-02-27T12:38:43+05:30
 draft: false
 summary: "Authenticity is always rewarded."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/27-3-22-sunday-funday.md
+++ b/content/dailies/27-3-22-sunday-funday.md
@@ -3,8 +3,6 @@ title: "#83 Sunday Funday"
 date: 2022-03-27T17:47:47+05:30
 draft: false
 summary: "Attended an event just to eat good Biriyani today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Tough one today.

--- a/content/dailies/27-3-23-charts.md
+++ b/content/dailies/27-3-23-charts.md
@@ -3,8 +3,6 @@ title: "#251 Charts"
 date: 2023-03-27T23:32:46+05:30
 draft: false
 summary: "My new-found love for charts."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I was obsessed with building charts since I learned how to build them from structured data with code.

--- a/content/dailies/27-4-22-look-what-i-bought.md
+++ b/content/dailies/27-4-22-look-what-i-bought.md
@@ -3,8 +3,6 @@ title: "#113 Look What I Bought"
 date: 2022-04-27T19:22:58+05:30
 draft: false
 summary: "Cool new shizz!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 312 5/6

--- a/content/dailies/27-5-22-cant-find-video-games.md
+++ b/content/dailies/27-5-22-cant-find-video-games.md
@@ -3,8 +3,6 @@ title: "#140 Can't Find Video Games"
 date: 2022-05-27T19:59:33+05:30
 draft: false
 summary: "Can't find a low end video game that is fun to play and won't burn my MacBook Air."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I finished _The Rise of the Tomb Raider_ today. Great game. Great storyline.

--- a/content/dailies/27-6-22-bike-ride.md
+++ b/content/dailies/27-6-22-bike-ride.md
@@ -3,8 +3,6 @@ title: "#161 Bike Ride"
 date: 2022-06-27T10:44:04+05:30
 draft: false
 summary: "Took my new motorcycle out for a ride."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Took my new motorcycle out for a ride today morning. It handles really well and I love it. Looking forward to more rides in this.

--- a/content/dailies/27-8-22-do-i-really-need-news.md
+++ b/content/dailies/27-8-22-do-i-really-need-news.md
@@ -3,8 +3,6 @@ title: "#195 Do I Really Need News?"
 date: 2022-08-27T22:38:16+05:30
 draft: false
 summary: "Really?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been following significantly less "news" recently.

--- a/content/dailies/27-9-22-namma-ooru-bengaluru.md
+++ b/content/dailies/27-9-22-namma-ooru-bengaluru.md
@@ -3,8 +3,6 @@ title: "#211 Namma Ooru Bengaluru"
 date: 2022-09-27T09:21:21+05:30
 draft: false
 summary: "I'm in Bangalore for the week. Bonus: Photos from Pune."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm in Bangalore for I don't know how long. It's going to be a conference week, a busy work week, a "meet friends I haven't seen for two years" week, cramped into one week.

--- a/content/dailies/28-1-22-i-am-my-experiences.md
+++ b/content/dailies/28-1-22-i-am-my-experiences.md
@@ -3,8 +3,6 @@ title: "#27 I Am My Experiences"
 date: 2022-01-28T11:14:22+05:30
 draft: false
 summary: "Mini-Boom! I _should_ have guessed it earlier."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Mini-Boom! I _should_ have guessed it earlier.

--- a/content/dailies/28-2-22-times-like-these.md
+++ b/content/dailies/28-2-22-times-like-these.md
@@ -3,8 +3,6 @@ title: "#56 Times Like These"
 date: 2022-02-28T18:57:16+05:30
 draft: false
 summary: "It's times like these time and time again."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 🇺🇦

--- a/content/dailies/28-3-22-back-on-twitter.md
+++ b/content/dailies/28-3-22-back-on-twitter.md
@@ -3,8 +3,6 @@ title: "#84 Back on Twitter"
 date: 2022-03-28T10:40:35+05:30
 draft: false
 summary: "Here we go tweetin' again!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I think I have exhausted all the captions for my Wordle scores.

--- a/content/dailies/28-3-23-tweets.md
+++ b/content/dailies/28-3-23-tweets.md
@@ -3,8 +3,6 @@ title: "#252 Tweets"
 date: 2023-03-28T22:43:31+05:30
 draft: false
 summary: "Tweets."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Tweets of the day.

--- a/content/dailies/28-4-22-wecrashed.md
+++ b/content/dailies/28-4-22-wecrashed.md
@@ -3,8 +3,6 @@ title: "#114 WeCrashed"
 date: 2022-04-28T18:51:49+05:30
 draft: false
 summary: "I never knew the WeWork story until this week."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Phew!

--- a/content/dailies/28-5-22-i-learned-obs.md
+++ b/content/dailies/28-5-22-i-learned-obs.md
@@ -3,8 +3,6 @@ title: "#141 I Learned OBS"
 date: 2022-05-28T19:42:26+05:30
 draft: false
 summary: "After all this time, I learn to work with OBS. It is really amazing and I'm disappointed I didn't use it earlier."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 After hearing about it for the last two years, I finally started using [Open Broadcaster Software](https://obsproject.com/) (OBS).

--- a/content/dailies/28-8-23-constant-external-stimulation.md
+++ b/content/dailies/28-8-23-constant-external-stimulation.md
@@ -3,8 +3,6 @@ title: "#275 Constant External Stimulation"
 date: 2023-08-28T10:53:33+05:30
 draft: false
 summary: "Turning down the external noise to clear the noise inside."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I drove alone for six hours this weekend. I spent the whole time listening to David Perell's new podcast, [How I Write](https://youtube.com/playlist?list=PLFxhXLgGkVzKCn23_g8qM19DMDgco8eNJ&si=b6lA2HvhmREyxPFO).

--- a/content/dailies/29-1-22-devconf-cz.md
+++ b/content/dailies/29-1-22-devconf-cz.md
@@ -3,8 +3,6 @@ title: "#28 DevConf.CZ"
 date: 2022-01-29T08:34:43+05:30
 draft: false
 summary: "Highlights from conference day."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Boom! Boom! Boom!

--- a/content/dailies/29-3-22-viral-on-twitter.md
+++ b/content/dailies/29-3-22-viral-on-twitter.md
@@ -3,8 +3,6 @@ title: "#85 Viral on Twitter"
 date: 2022-03-29T10:47:34+05:30
 draft: false
 summary: "My tweet went viral."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Too close for comfort.

--- a/content/dailies/29-4-22-back-after-two-years.md
+++ b/content/dailies/29-4-22-back-after-two-years.md
@@ -3,8 +3,6 @@ title: "#115 Back After Two Years"
 date: 2022-04-29T22:33:01+05:30
 draft: false
 summary: "Back with a new version."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 314 4/6

--- a/content/dailies/29-5-22-its-always-sunny.md
+++ b/content/dailies/29-5-22-its-always-sunny.md
@@ -3,8 +3,6 @@ title: "#142 It's Always Sunny"
 date: 2022-05-29T23:45:51+05:30
 draft: false
 summary: "Race day, IPL Final day, and rewatching an old gem."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 What a race in Monaco!

--- a/content/dailies/29-8-22-opinions-about-the-metaverse.md
+++ b/content/dailies/29-8-22-opinions-about-the-metaverse.md
@@ -3,8 +3,6 @@ title: "#196 Opinions About the Metaverse"
 date: 2022-08-29T11:33:40+05:30
 draft: false
 summary: "TLDR; I don't like it. Bonus: Pictures!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been listening to Mark Zuckerberg's conversation with Joe Rogan and sharing my opinions on Twitter. I'm almost halfway through it.

--- a/content/dailies/3-1-22-my-blog-setup-and-writing-process.md
+++ b/content/dailies/3-1-22-my-blog-setup-and-writing-process.md
@@ -3,8 +3,6 @@ title: "#4 My Blog Setup and Writing Process"
 date: 2022-01-03T16:02:01+05:30
 draft: false
 summary: "I recently started writing on my own website. Here's a look into my setup and the process I follow to write posts."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ShowToc: true
 TocOpen: true
 ---

--- a/content/dailies/3-11-22-buying-raspberry-pis.md
+++ b/content/dailies/3-11-22-buying-raspberry-pis.md
@@ -3,8 +3,6 @@ title: "#220 Buying Raspberry Pis"
 date: 2022-11-03T18:55:00+05:30
 draft: false
 summary: "The lack of availability of Raspberry Pis could be a case study for the global supply chain problem."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 After at least half a year of searching, I finally have my hands on a [Raspberry Pi Computer Module 4](https://www.raspberrypi.com/products/compute-module-4/?variant=raspberry-pi-cm4001000).

--- a/content/dailies/3-2-22-poetry.md
+++ b/content/dailies/3-2-22-poetry.md
@@ -3,8 +3,6 @@ title: "#33 Poetry"
 date: 2022-02-03T08:22:23+05:30
 draft: false
 summary: "I haven't been much of a poetry reader."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It is all about calculated eliminations.

--- a/content/dailies/3-3-22-shine-of-novelty-and-consistency-of-commitment.md
+++ b/content/dailies/3-3-22-shine-of-novelty-and-consistency-of-commitment.md
@@ -3,8 +3,6 @@ title: "#59 Shine of Novelty and Consistency of Commitment"
 date: 2022-03-03T17:46:18+05:30
 draft: false
 summary: "Ooh shiny!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I beat my roommate today. In Wordle that is.

--- a/content/dailies/3-4-22-it-works.md
+++ b/content/dailies/3-4-22-it-works.md
@@ -3,8 +3,6 @@ title: "#90 It Works!"
 date: 2022-04-03T13:21:36+05:30
 draft: false
 summary: "My USB hub setup seems to work. Waiting for my new microphone to arrive tomorrow. Plus, I read a lot about Singapore today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm back in easy mode.

--- a/content/dailies/3-4-23-migration.md
+++ b/content/dailies/3-4-23-migration.md
@@ -3,8 +3,6 @@ title: "#255 Migration"
 date: 2023-04-03T23:57:15+05:30
 draft: false
 summary: "New diagrams and a binge-worthy blog."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm in the process of migrating/redrawing diagrams in this blog from Mermaid.js to PNG diagrams from Canva.

--- a/content/dailies/3-5-22-new-projects.md
+++ b/content/dailies/3-5-22-new-projects.md
@@ -3,8 +3,6 @@ title: "#119 New Projects"
 date: 2022-05-03T19:47:47+05:30
 draft: false
 summary: "Starting some new projects."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Fifth month of this and it is still exciting.

--- a/content/dailies/3-6-22-vikram.md
+++ b/content/dailies/3-6-22-vikram.md
@@ -3,8 +3,6 @@ title: "#147 Vikram"
 date: 2022-06-03T21:56:47+05:30
 draft: false
 summary: 'Watched the new movie "Vikram" filled with a stellar cast.'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I watched the new movie _Vikram_ starring Kamal Haasan, Fahad Fazil, Vijay Sethupathi, and other stars (no spoilers).

--- a/content/dailies/3-9-22-side-project-saturday.md
+++ b/content/dailies/3-9-22-side-project-saturday.md
@@ -3,8 +3,6 @@ title: "#201 Side Project Saturday"
 date: 2022-09-03T22:52:06+05:30
 draft: false
 summary: "Working on side projects, writing, and AI images."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I spent the day working on my newsletter and blog. A new newsletter issue and a blog post will be published this Friday.

--- a/content/dailies/30-1-22-running-shoes-and-investing-in-myself.md
+++ b/content/dailies/30-1-22-running-shoes-and-investing-in-myself.md
@@ -3,8 +3,6 @@ title: "#29 Running Shoes and Investing in Myself"
 date: 2022-01-30T08:31:29+05:30
 draft: false
 summary: "It wasn’t an obvious one today but I got the right letters in the third step and I had already eliminated other possible vowels that could go between the two correct letters."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It wasn't an obvious one today but I got the right letters in the third step and I had already eliminated other possible vowels that could go between the two correct letters.

--- a/content/dailies/30-3-22-debates-are-pointless.md
+++ b/content/dailies/30-3-22-debates-are-pointless.md
@@ -3,8 +3,6 @@ title: "#86 Debates Are Pointless"
 date: 2022-03-30T22:34:13+05:30
 draft: false
 summary: "Will Smith slapped Chris Rock and now we can't have a peaceful dinner."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 How clever is Wordle's user experience?

--- a/content/dailies/30-4-22-clever-subtitles.md
+++ b/content/dailies/30-4-22-clever-subtitles.md
@@ -3,8 +3,6 @@ title: "#116 Clever Subtitles"
 date: 2022-04-30T19:27:03+05:30
 draft: false
 summary: "Pachinko tells stories in subtitles and I submitted a couple of talk proposals."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It was a lucky guess.

--- a/content/dailies/30-5-22-looking-for-retropies.md
+++ b/content/dailies/30-5-22-looking-for-retropies.md
@@ -3,8 +3,6 @@ title: "#143 Looking for RetroPies"
 date: 2022-05-30T20:43:56+05:30
 draft: false
 summary: "Kids be buying PS5s. Me be buying RetroPies."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 If you are a reader here, you would not be a stranger to my recent video game adventures.

--- a/content/dailies/30-8-22-might-as-well-get-a-certificate-that-says-i-know-kubernetes.md
+++ b/content/dailies/30-8-22-might-as-well-get-a-certificate-that-says-i-know-kubernetes.md
@@ -3,8 +3,6 @@ title: "#197 Might as Well Get a Certificate That Says I Know Kubernetes"
 date: 2022-08-30T21:26:29+05:30
 draft: false
 summary: "I'm taking the CKAD examination."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I purchased the Certified Kubernetes Application Developer (CKAD) examination today. I haven't scheduled a test yet, but I will in the coming months after I finish some travel.

--- a/content/dailies/30-9-22-namma-ooru-bengaluru-2.md
+++ b/content/dailies/30-9-22-namma-ooru-bengaluru-2.md
@@ -3,8 +3,6 @@ title: "#212 Namma Ooru Bengaluru 2"
 date: 2022-09-30T08:45:21+05:30
 draft: false
 summary: "Speaking at Open Source India and meeting old friends. Bonus: Photos from Bangalore."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/30-9-22-namma-ooru-bengaluru-2/bangalore-dudes.jpeg#center" title="I finally meet my friends after two years!" caption="Watson's, Indiranagar, Bangalore - 27th September 2022" link="/images/30-9-22-namma-ooru-bengaluru-2/bangalore-dudes.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/31-1-22-a-month-in-the-life-of.md
+++ b/content/dailies/31-1-22-a-month-in-the-life-of.md
@@ -3,8 +3,6 @@ title: "#30 A Month in the Life Of"
 date: 2022-01-31T18:47:59+05:30
 draft: false
 summary: "It's been a month since I started writing daily logs."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I need to be more careful. I am turning on the hard mode from tomorrow.

--- a/content/dailies/31-1-22-a-month-in-the-life-of.md
+++ b/content/dailies/31-1-22-a-month-in-the-life-of.md
@@ -15,7 +15,7 @@ Wordle 226 5/6
 🟨⬛🟨🟨🟩\
 🟩🟩🟩🟩🟩
 
-It's been a month since I started _[Daily Logs](/categories/daily-dose-of-pottekkat/)_.
+It's been a month since I started _[Daily Logs](/dailies/)_.
 
 Writing everyday has helped me articulate my thoughts and build a habit.
 

--- a/content/dailies/31-12-21-new-year-new-me.md
+++ b/content/dailies/31-12-21-new-year-new-me.md
@@ -4,8 +4,6 @@ date: 2021-12-31T21:15:25+05:30
 draft: false
 ShowToc: false
 summary: "I will blog daily. Or at least I hope to."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It's the last day of the year. It might as well be my first daily log.

--- a/content/dailies/31-3-22-writing-plans.md
+++ b/content/dailies/31-3-22-writing-plans.md
@@ -3,8 +3,6 @@ title: "#87 Writing Plans"
 date: 2022-03-31T09:28:10+05:30
 draft: false
 summary: "Plans for writing."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Bad week on Wordle.

--- a/content/dailies/31-5-22-bullet.md
+++ b/content/dailies/31-5-22-bullet.md
@@ -3,8 +3,6 @@ title: "#144 Bullet"
 date: 2022-05-31T19:15:05+05:30
 draft: false
 summary: "My motorcycle is older than me."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have a 95' Royal Enfield Bullet. It was in the shop till April, and now it's back good as new.

--- a/content/dailies/31-8-22-sideprojectception.md
+++ b/content/dailies/31-8-22-sideprojectception.md
@@ -3,8 +3,6 @@ title: "#198 SideProjectCeption"
 date: 2022-08-31T21:30:59+05:30
 draft: false
 summary: "Finish side projects or start more side projects?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Do you also face this issue where you start working on more side projects instead of completing the ones you already started?

--- a/content/dailies/4-1-22-word-embeddings-and-swiss-army-knives.md
+++ b/content/dailies/4-1-22-word-embeddings-and-swiss-army-knives.md
@@ -66,4 +66,4 @@ My goal for the not so far future is to build products on my own and monetize th
 
 So, being a utility player should help me out.
 
-Five days into [writing daily](/categories/daily-dose-of-pottekkat/). I'm lovin it!
+Five days into [writing daily](/dailies/). I'm lovin it!

--- a/content/dailies/4-1-22-word-embeddings-and-swiss-army-knives.md
+++ b/content/dailies/4-1-22-word-embeddings-and-swiss-army-knives.md
@@ -3,8 +3,6 @@ title: "#5 Word Embeddings and Swiss Army Knives"
 date: 2022-01-04T10:36:58+05:30
 draft: false
 summary: "What's cooler than representing words as real-valued vectors to capture its semantic meaning?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< blockquote author="Elon Musk" link="https://www.youtube.com/watch?v=ViOdlRzq3MY" title="When asked about SpaceX" >}}

--- a/content/dailies/4-12-22-benki-benki-boom-boom.md
+++ b/content/dailies/4-12-22-benki-benki-boom-boom.md
@@ -3,8 +3,6 @@ title: "#230 Benki, Benki, Boom, Boom!"
 date: 2022-12-04T20:05:05+05:30
 draft: false
 summary: "Travelling to Kannur. Bonus: Photos!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/4-12-22-benki-benki-boom-boom/gang-signs.jpg#center" title="Coolest gang signs" caption="Kannapuram, Kannur - 4th December 2022" link="/images/4-12-22-benki-benki-boom-boom/gang-signs.jpg" target="_blank" class="align-center" >}}

--- a/content/dailies/4-2-22-winner-takes-all.md
+++ b/content/dailies/4-2-22-winner-takes-all.md
@@ -3,8 +3,6 @@ title: "#34 Winner Takes All"
 date: 2022-02-04T20:12:24+05:30
 draft: false
 summary: "The winner takes it all. It is a training algorithm for neural networks."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It was a good guess today.

--- a/content/dailies/4-2-23-curiosity.md
+++ b/content/dailies/4-2-23-curiosity.md
@@ -3,8 +3,6 @@ title: "#238 Curiosity"
 date: 2023-02-04T20:36:10+05:30
 draft: false
 summary: "Driven by curiosity."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm reading xkcd's [what if? 2](https://www.goodreads.com/en/book/show/60190659) right now, and what if? is a book I recommend to everyone.

--- a/content/dailies/4-3-22-a-day-off.md
+++ b/content/dailies/4-3-22-a-day-off.md
@@ -3,8 +3,6 @@ title: "#60 A Day Off"
 date: 2022-03-04T18:15:40+05:30
 draft: false
 summary: "I kind of took a day off. Whoa! 60 days!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Easy.

--- a/content/dailies/4-4-22-apache-apisix-has-a-lot-of-plugins.md
+++ b/content/dailies/4-4-22-apache-apisix-has-a-lot-of-plugins.md
@@ -3,8 +3,6 @@ title: "#91 Apache APISIX Has a Lot of Plugins"
 date: 2022-04-04T22:28:08+05:30
 draft: false
 summary: "Doing a lot of work in rewriting the Apache APISIX documentation."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I don't want to "jinx it" by calling this streak.

--- a/content/dailies/4-5-22-ownership.md
+++ b/content/dailies/4-5-22-ownership.md
@@ -3,8 +3,6 @@ title: "#120 Ownership"
 date: 2022-05-04T19:57:15+05:30
 draft: false
 summary: "Owning your work makes you more productive."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Some days, I play to just keep up with the streak.

--- a/content/dailies/4-6-22-planning-a-road-trip.md
+++ b/content/dailies/4-6-22-planning-a-road-trip.md
@@ -3,8 +3,6 @@ title: "#148 Planning a Road Trip"
 date: 2022-06-04T19:30:45+05:30
 draft: false
 summary: "We can ride on my motorcycle."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm thinking of going on a road trip—a motorcycle trip—in one of the coming weekends.

--- a/content/dailies/4-6-23-obsession-overload.md
+++ b/content/dailies/4-6-23-obsession-overload.md
@@ -3,8 +3,6 @@ title: "#265 Obsession Overload"
 date: 2023-06-04T11:21:19+05:30
 draft: false
 summary: "Obsessed about obsessions."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It is in my fundamental nature to obsess over things. I have learned that it is central to who I am. And it is great.

--- a/content/dailies/4-8-22-cluecon-weekly.md
+++ b/content/dailies/4-8-22-cluecon-weekly.md
@@ -3,8 +3,6 @@ title: "#173 ClueCon Weekly"
 date: 2022-08-04T19:49:55+05:30
 draft: false
 summary: "I was invited to be a guest on this week's ClueCon Weekly!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I had a lot of fun talking about Apache APISIX, open source contributions, the state of open source projects, formal computer science education, developer advocacy, careers in open source, and more.

--- a/content/dailies/4-9-22-homecoming.md
+++ b/content/dailies/4-9-22-homecoming.md
@@ -3,8 +3,6 @@ title: "#202 Homecoming"
 date: 2022-09-04T23:32:08+05:30
 draft: false
 summary: "Photos we took today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/4-9-22-homecoming/fam.jpeg#center" title="Fam" caption="Chittur - 4th September 2022" link="/images/4-9-22-homecoming/fam.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/5-1-22-right-arm-over-the-wicket.md
+++ b/content/dailies/5-1-22-right-arm-over-the-wicket.md
@@ -3,8 +3,6 @@ title: "#6 Right Arm Over the Wicket or Why I use my Own Platform to Write"
 date: 2022-01-05T13:08:11+05:30
 draft: false
 summary: "I used to write on blogging platforms like Medium and DEV.to. I stopped using them and started writing on my own blog recently. Here, I explore why I chose to do that and make bold predictions on the outcome of a cricket match."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 [India is playing South Africa](https://www.google.com/search?q=ind+vs+sa) and I'm really excited for day four. It may seem one sided now and an easy win for the Proteas but the scores don't tell the whole story.

--- a/content/dailies/5-11-22-new-explorations.md
+++ b/content/dailies/5-11-22-new-explorations.md
@@ -3,8 +3,6 @@ title: "#221 New Explorations"
 date: 2022-11-05T19:44:03+05:30
 draft: false
 summary: 'Writing a lot of new articles and exploring new "genres" for articles.'
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 My writing schedule seems to be working well.

--- a/content/dailies/5-2-23-movie-marathon-ish.md
+++ b/content/dailies/5-2-23-movie-marathon-ish.md
@@ -3,8 +3,6 @@ title: "#239 Movie Marathon-ish"
 date: 2023-02-05T22:01:46+05:30
 draft: false
 summary: "Watched two movies today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I went to watch Nanpakal Nerathu Mayakkam and Romancham today. A day well spent.

--- a/content/dailies/5-3-22-the-day-off.md
+++ b/content/dailies/5-3-22-the-day-off.md
@@ -3,8 +3,6 @@ title: "#61 The Day Off"
 date: 2022-03-05T10:17:45+05:30
 draft: false
 summary: "Chill."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I took the day off to read.

--- a/content/dailies/5-4-22-a-lot-happened-today.md
+++ b/content/dailies/5-4-22-a-lot-happened-today.md
@@ -3,8 +3,6 @@ title: "#92 A Lot Happened Today"
 date: 2022-04-05T17:47:01+05:30
 draft: false
 summary: "I'm going to KubeCon, my microphone arrived, I went to a film festival and I need to get a visa."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Too big of a day to care about my Wordle score.

--- a/content/dailies/5-5-22-hard-work-and-hustle.md
+++ b/content/dailies/5-5-22-hard-work-and-hustle.md
@@ -3,8 +3,6 @@ title: "#121 Hard Work and Hustle"
 date: 2022-05-05T11:51:18+05:30
 draft: false
 summary: "Hardworking is undermined and not considered cool anymore. Don't cancel me."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 These American words.

--- a/content/dailies/5-6-22-environment-day.md
+++ b/content/dailies/5-6-22-environment-day.md
@@ -3,8 +3,6 @@ title: "#149 Environment Day"
 date: 2022-06-05T21:05:32+05:30
 draft: false
 summary: "Living in a small town has its own set of perks."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Living in a small town has its own set of perks.

--- a/content/dailies/5-8-22-weekend-plans.md
+++ b/content/dailies/5-8-22-weekend-plans.md
@@ -3,8 +3,6 @@ title: "#174 Weekend Plans"
 date: 2022-08-05T19:54:42+05:30
 draft: false
 summary: "I can finally start working on my side projects!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Side projects, here I come!

--- a/content/dailies/5-9-22-going-wireless.md
+++ b/content/dailies/5-9-22-going-wireless.md
@@ -3,8 +3,6 @@ title: "#203 Going Wireless"
 date: 2022-09-05T23:27:16+05:30
 draft: false
 summary: "How fast did we go wireless?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It feels like yesterday when we all had wires on our devices. Now all of a sudden, people seem to have gone wireless.

--- a/content/dailies/6-1-22-why-i-run-in-the-morning.md
+++ b/content/dailies/6-1-22-why-i-run-in-the-morning.md
@@ -3,8 +3,6 @@ title: "#7 Why I Run in the Morning"
 date: 2022-01-06T19:49:10+05:30
 draft: false
 summary: "Doing hard things is hard. But you have to do it to be the best version of yourself. Everyday is a struggle but at the end of the day I'm happy I chose to do the hard things."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Running 8 km (~5 mi) is the first thing I do every morning.

--- a/content/dailies/6-10-22-chill-maadi.md
+++ b/content/dailies/6-10-22-chill-maadi.md
@@ -3,8 +3,6 @@ title: "#213 Chill Maadi"
 date: 2022-10-06T22:15:14+05:30
 draft: false
 summary: "I'm back home for good. Bonus: Photos."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm finally back home after almost a month of travel. Traveling is fun but exhausting.

--- a/content/dailies/6-2-22-back-to-code.md
+++ b/content/dailies/6-2-22-back-to-code.md
@@ -3,8 +3,6 @@ title: "#35 Back to Code"
 date: 2022-02-06T19:53:39+05:30
 draft: false
 summary: "I go back to writing code."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Got there eventually.

--- a/content/dailies/6-2-23-happy-kubecon-proposal-notification-day.md
+++ b/content/dailies/6-2-23-happy-kubecon-proposal-notification-day.md
@@ -3,8 +3,6 @@ title: "#240 Happy KubeCon Proposal Notification Day"
 date: 2023-02-06T22:41:31+05:30
 draft: false
 summary: "Happy Rejekts proposal submission day!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Long story short, my KubeCon proposal was rejected.

--- a/content/dailies/6-3-22-batman.md
+++ b/content/dailies/6-3-22-batman.md
@@ -3,8 +3,6 @@ title: "#62 Batman"
 date: 2022-03-06T10:27:55+05:30
 draft: false
 summary: "I got tickets to watch the new Batman movie today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Just when I thought I had it in two.

--- a/content/dailies/6-4-22-phew.md
+++ b/content/dailies/6-4-22-phew.md
@@ -3,8 +3,6 @@ title: "#93 Phew!"
 date: 2022-04-06T21:40:23+05:30
 draft: false
 summary: "Busy days."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Phew!

--- a/content/dailies/6-5-22-just-wordle.md
+++ b/content/dailies/6-5-22-just-wordle.md
@@ -3,8 +3,6 @@ title: "#122 Just Wordle (Idea Stew)"
 date: 2022-05-06T11:32:54+05:30
 draft: false
 summary: "I don't have anything interesting to share today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Here is my Wordle score today and a sentence that shows how much I try to be funny but fail.

--- a/content/dailies/6-6-22-video-of-my-bike.md
+++ b/content/dailies/6-6-22-video-of-my-bike.md
@@ -3,8 +3,6 @@ title: "#150 Video of My Bike"
 date: 2022-06-06T19:42:41+05:30
 draft: false
 summary: "150 days of writing! I have a small video for you today."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Here is me revving up our 1995 Royal Enfield Bullet 350.

--- a/content/dailies/6-6-24-three-villages-in-a-trench-coat.md
+++ b/content/dailies/6-6-24-three-villages-in-a-trench-coat.md
@@ -3,8 +3,6 @@ title: "#283 Three Villages in a Trench Coat"
 date: 2024-06-06T18:48:54+02:00
 draft: false
 summary: "This place is beautiful!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 While walking around Bratislava, you constantly remind yourself that you are in a capital city when all around you feel the warmth and coziness of a small village.

--- a/content/dailies/6-7-22-derailed.md
+++ b/content/dailies/6-7-22-derailed.md
@@ -3,8 +3,6 @@ title: "#162 Derailed"
 date: 2022-07-06T21:48:37+05:30
 draft: false
 summary: "I've been off the tracks these past weeks. Need to get back to the consistency."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 You have a busy week, and the next thing you know, you are off the tracks on your daily routines.

--- a/content/dailies/6-8-22-building-a-redis-clone.md
+++ b/content/dailies/6-8-22-building-a-redis-clone.md
@@ -3,8 +3,6 @@ title: "#175 Building a Redis Clone"
 date: 2022-08-06T20:57:19+05:30
 draft: false
 summary: "I learn about Redis and build a Redis clone."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I built a Redis clone today following the tutorial from [codecrafters.io](https://codecrafters.io/).

--- a/content/dailies/7-1-22-the-psychology-of-money.md
+++ b/content/dailies/7-1-22-the-psychology-of-money.md
@@ -3,8 +3,6 @@ title: "#8 The Psychology of Money"
 date: 2022-01-08T08:28:58+05:30
 draft: false
 summary: "There is no reason to risk what you have and need for what you don’t have and don’t need."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Today I started reading "[The Psychology of Money](https://www.goodreads.com/book/show/41881472-the-psychology-of-money)" by Morgan Housel and I am four chapters in already.

--- a/content/dailies/7-11-22-dead-end.md
+++ b/content/dailies/7-11-22-dead-end.md
@@ -3,8 +3,6 @@ title: "#222 Dead End"
 date: 2022-11-07T22:34:29+05:30
 draft: false
 summary: "Fail fast."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 So, I spent the whole weekend on the project I mentioned last time. Turns out, it is really difficult and not worth it for what I'm trying to achieve.

--- a/content/dailies/7-2-22-not-knowing.md
+++ b/content/dailies/7-2-22-not-knowing.md
@@ -3,8 +3,6 @@ title: "#36 Not Knowing"
 date: 2022-02-07T20:20:20+05:30
 draft: false
 summary: "I know nothing."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 This should have taken at least a step less.

--- a/content/dailies/7-3-22-technical-writing-and-going-solar.md
+++ b/content/dailies/7-3-22-technical-writing-and-going-solar.md
@@ -3,8 +3,6 @@ title: "#63 Technical Writing and Going Solar"
 date: 2022-03-07T19:37:29+05:30
 draft: false
 summary: "It ain't much, but it's honest work."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It ain't much, but it's honest work.

--- a/content/dailies/7-4-22-setting-up-for-visa-appointment.md
+++ b/content/dailies/7-4-22-setting-up-for-visa-appointment.md
@@ -3,8 +3,6 @@ title: "#94 Setting Up for Visa Appointment"
 date: 2022-04-07T19:07:31+05:30
 draft: false
 summary: "I spent the whole day setting up the documents needed for a visa."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I forgot to copy the Wordle score.

--- a/content/dailies/7-4-23-api-gateway-and-service-mesh.md
+++ b/content/dailies/7-4-23-api-gateway-and-service-mesh.md
@@ -3,8 +3,6 @@ title: "#256 API Gateway and Service Mesh"
 date: 2023-04-07T21:59:20+05:30
 draft: false
 summary: "How do I go about writing this article?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm working on a new article comparing service mesh and API gateway technologies.

--- a/content/dailies/7-5-22-strange.md
+++ b/content/dailies/7-5-22-strange.md
@@ -3,8 +3,6 @@ title: "#123 Strange"
 date: 2022-05-07T23:46:34+05:30
 draft: false
 summary: "Watched the new Dr. Strange movie."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Another day, another missed Wordle.

--- a/content/dailies/7-5-24-ocd.md
+++ b/content/dailies/7-5-24-ocd.md
@@ -3,8 +3,6 @@ title: "#280 OCD"
 date: 2024-05-07T13:08:41+05:30
 draft: false
 summary: "A harmless tweak of my blog triggered irrational compulsions."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 AAAAAAAH!

--- a/content/dailies/7-6-22-test.md
+++ b/content/dailies/7-6-22-test.md
@@ -3,8 +3,6 @@ title: "#151 Test"
 date: 2022-06-07T20:56:49+05:30
 draft: false
 summary: "I can binge watch epic test cricket moments anytime, any day."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Test cricket is undoubtedly the best format for playing cricket.

--- a/content/dailies/7-7-22-rainy-day-ride.md
+++ b/content/dailies/7-7-22-rainy-day-ride.md
@@ -3,8 +3,6 @@ title: "#163 Rainy Day Ride"
 date: 2022-07-07T19:57:44+05:30
 draft: false
 summary: "I went on a rainy day ride. Rain, not for me."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 And, I have decided that I don't like riding in pouring rain.

--- a/content/dailies/7-8-22-building-a-docker-clone-and-starting-a-side-project.md
+++ b/content/dailies/7-8-22-building-a-docker-clone-and-starting-a-side-project.md
@@ -3,8 +3,6 @@ title: "#176 Building a Docker Clone and Starting a Side Project"
 date: 2022-08-07T22:57:49+05:30
 draft: false
 summary: "Learning how Docker works and finally getting started on my side project. Posting publicly for accountability."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 After finishing the Redis clone from yesterday, I started building a Docker clone.

--- a/content/dailies/7-9-22-ckad-reviews-and-imposter-syndrome.md
+++ b/content/dailies/7-9-22-ckad-reviews-and-imposter-syndrome.md
@@ -3,8 +3,6 @@ title: "#204 CKAD, Reviews, and Imposter Syndrome"
 date: 2022-09-07T21:58:39+05:30
 draft: false
 summary: "It is real."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been using my free time to prepare for the CKAD examination. Since my current focus at work is on ingress controllers, it works out very well.

--- a/content/dailies/8-1-22-the-end-of-history.md
+++ b/content/dailies/8-1-22-the-end-of-history.md
@@ -3,8 +3,6 @@ title: "#9 The End of History"
 date: 2022-01-08T14:22:02+05:30
 draft: false
 summary: "People are unable to predict their personal changes. We see ourselves as finished products at any point of time. Is that the end of history?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 People believe that they have experienced significant personal growth and changes in tastes up to the present moment but will not substantially grow or mature in the future.

--- a/content/dailies/8-2-22-malayalees-and-their-lulu-malls.md
+++ b/content/dailies/8-2-22-malayalees-and-their-lulu-malls.md
@@ -3,8 +3,6 @@ title: "#37 Malayalees and Their LuLu Malls"
 date: 2022-02-08T20:44:15+05:30
 draft: false
 summary: "Mallus love their LuLus."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Mallus love their LuLus.

--- a/content/dailies/8-3-22-i-should-learn-to-use-vim.md
+++ b/content/dailies/8-3-22-i-should-learn-to-use-vim.md
@@ -3,8 +3,6 @@ title: "#64 I Should Learn to Use Vim"
 date: 2022-03-08T10:36:22+05:30
 draft: false
 summary: "Vim or Emacs? Nano."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 262 3/6

--- a/content/dailies/8-4-22-growing-to-be-read-pile.md
+++ b/content/dailies/8-4-22-growing-to-be-read-pile.md
@@ -3,8 +3,6 @@ title: '#95 Growing "to be read" Pile'
 date: 2022-04-08T18:40:39+05:30
 draft: false
 summary: "When will I read all these and close all these tabs?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Wordle 293 3/6

--- a/content/dailies/8-4-23-wikipedia-rabbit-holes.md
+++ b/content/dailies/8-4-23-wikipedia-rabbit-holes.md
@@ -3,8 +3,6 @@ title: "#257 Wikipedia Rabbit Holes"
 date: 2023-04-08T19:05:49+05:30
 draft: false
 summary: "Wikipedia is an unpredictable rabbit hole."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been binging Wikipedia articles all evening. I will let the links tell the story.

--- a/content/dailies/8-5-22-football.md
+++ b/content/dailies/8-5-22-football.md
@@ -3,8 +3,6 @@ title: "#124 Football"
 date: 2022-05-08T20:35:31+05:30
 draft: false
 summary: "The American one."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I swear I did Wordle but didn't save the score.

--- a/content/dailies/8-6-22-highway-to-the-danger-zone.md
+++ b/content/dailies/8-6-22-highway-to-the-danger-zone.md
@@ -3,8 +3,6 @@ title: "#152 Highway to the Danger Zone"
 date: 2022-06-08T23:22:17+05:30
 draft: false
 summary: "Traveled 60 kms to watch Top Gun: Maverick"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 We traveled nearly 60 kms yesterday evening to catch the new Top Gun movie. It was totally worth it.

--- a/content/dailies/8-7-22-goodbyes.md
+++ b/content/dailies/8-7-22-goodbyes.md
@@ -3,8 +3,6 @@ title: "#164 Goodbyes"
 date: 2022-07-08T20:27:43+05:30
 draft: false
 summary: "It's an end of an era."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Today might be an end of an era. The last month was quite fun with all my friends back in our hometown. And today, everyone is leaving.

--- a/content/dailies/8-8-22-preparing-for-open-source-summit-latin-america.md
+++ b/content/dailies/8-8-22-preparing-for-open-source-summit-latin-america.md
@@ -3,8 +3,6 @@ title: "#177 Preparing for Open Source Summit Latin America"
 date: 2022-08-08T20:47:56+05:30
 draft: false
 summary: "Preparing for my virtual talk at OSS LA!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I will speak at the Open Source Summit Latin America hosted by the Linux Foundation.

--- a/content/dailies/8-9-22-onam.md
+++ b/content/dailies/8-9-22-onam.md
@@ -3,8 +3,6 @@ title: "#205 Onam"
 date: 2022-09-08T21:08:47+05:30
 draft: false
 summary: "Even gods envy you. Photos only."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< figure src="/images/8-9-22-onam/pookkalam.jpeg#center" title="The Pookkalam" caption="Chittur - 8th September 2022" link="/images/8-9-22-onam/pookkalam.jpeg" target="_blank" class="align-center" >}}

--- a/content/dailies/9-1-22-what-should-i-write-about.md
+++ b/content/dailies/9-1-22-what-should-i-write-about.md
@@ -3,8 +3,6 @@ title: "#10 What Should I Write About?"
 date: 2022-01-09T19:54:21+05:30
 draft: false
 summary: "What?"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 It is really cool to have a place on the internet to post my unfiltered ramblings everyday.

--- a/content/dailies/9-1-23-updates-from-the-last-few-weeks.md
+++ b/content/dailies/9-1-23-updates-from-the-last-few-weeks.md
@@ -3,8 +3,6 @@ title: "#233 Updates From the Last Few Weeks"
 date: 2023-01-09T10:47:42+05:30
 draft: false
 summary: "It's a new year!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I started writing these on 31st December 2021. As the year progressed, I managed to decline my consistency.

--- a/content/dailies/9-2-22-back-to-twitter.md
+++ b/content/dailies/9-2-22-back-to-twitter.md
@@ -3,8 +3,6 @@ title: "#38 Back to Twitter"
 date: 2022-02-09T12:37:48+05:30
 draft: false
 summary: "I'm back on Twitter!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Took a lot of tries to find the letters!

--- a/content/dailies/9-2-23-good-morning-from-singapore.md
+++ b/content/dailies/9-2-23-good-morning-from-singapore.md
@@ -3,8 +3,6 @@ title: "#241 Good Morning From Singapore!"
 date: 2023-02-09T07:27:17+08:00
 draft: false
 summary: "I'm in Singapore for a week!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Good morning from Singapore!

--- a/content/dailies/9-3-22-i-received-my-writers-copy.md
+++ b/content/dailies/9-3-22-i-received-my-writers-copy.md
@@ -3,8 +3,6 @@ title: "#65 I Received My Writers Copy"
 date: 2022-03-09T18:10:34+05:30
 draft: false
 summary: "My talk was transcribed into an article and published in the Open Source For You Magazine. I got my author's copy today!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I almost forgot.

--- a/content/dailies/9-4-22-travelling-to-mumbai.md
+++ b/content/dailies/9-4-22-travelling-to-mumbai.md
@@ -3,8 +3,6 @@ title: "#96 Travelling to Mumbai"
 date: 2022-04-09T17:35:36+05:30
 draft: false
 summary: "I have an early morning flight to Mumbai tomorrow."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I found out that I broke my streak the day before. But I'm back and kicking!

--- a/content/dailies/9-4-23-what-drives-you.md
+++ b/content/dailies/9-4-23-what-drives-you.md
@@ -3,8 +3,6 @@ title: "#258 What Drives You?"
 date: 2023-04-09T20:04:51+05:30
 draft: false
 summary: "Narrowing what drives me and my future plans."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I think it is so stupid that we have to figure out what we want to do when we are 18.

--- a/content/dailies/9-5-22-skyline.md
+++ b/content/dailies/9-5-22-skyline.md
@@ -3,8 +3,6 @@ title: "#125 Skyline"
 date: 2022-05-09T17:22:36+05:30
 draft: false
 summary: "3D print reveal. Bonus: Photos!"
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 Too sunny!

--- a/content/dailies/9-5-24-joy.md
+++ b/content/dailies/9-5-24-joy.md
@@ -3,8 +3,6 @@ title: "#281 Joy"
 date: 2024-05-09T17:21:17+05:30
 draft: false
 summary: "I'm a hypocrite."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I'm a hypocrite.

--- a/content/dailies/9-6-22-you-wont-believe-what-he-did-with-his-bike.md
+++ b/content/dailies/9-6-22-you-wont-believe-what-he-did-with-his-bike.md
@@ -3,8 +3,6 @@ title: "#153 You Won't Believe What He Did With His Bike"
 date: 2022-06-09T20:09:33+05:30
 draft: false
 summary: "No you won't."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 {{< youtube csdSibIllEI >}}

--- a/content/dailies/9-7-22-new-day-new-city.md
+++ b/content/dailies/9-7-22-new-day-new-city.md
@@ -3,8 +3,6 @@ title: "#165 New Day, New City"
 date: 2022-07-09T22:40:13+05:30
 draft: false
 summary: "Home away from home."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I will be in Trivandrum for a week.

--- a/content/dailies/9-8-22-recording-a-talk.md
+++ b/content/dailies/9-8-22-recording-a-talk.md
@@ -3,8 +3,6 @@ title: "#178 Recording a Talk"
 date: 2022-08-09T20:04:36+05:30
 draft: false
 summary: "I forgot to set the stopwatch and I spoke for 37 minutes."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I have been known to not get off the stage during conferences.

--- a/content/dailies/9-9-22-new-blog-post.md
+++ b/content/dailies/9-9-22-new-blog-post.md
@@ -3,8 +3,6 @@ title: "#206 New Blog Post"
 date: 2022-09-09T22:08:21+05:30
 draft: false
 summary: "Conference season September begins."
-tags: ["daily log"]
-categories: ["Daily Dose of Pottekkat"]
 ---
 
 I published a [new blog post](/posts/hands-on-set-up-ingress-on-kubernetes-with-apache-apisix-ingress-controller/) today. It is a "get your hands dirty" in Kubernetes kind of tutorial.

--- a/content/dailies/_index.md
+++ b/content/dailies/_index.md
@@ -12,6 +12,6 @@ Welcome to my daily logs! Here are a few notes (warnings) before you scroll down
 3. These are raw and unedited. I might say stuff and then evolve out of it in a year. The past me is not the present me; the present me is not the future me.
 4. Don't read these.
 5. Please don't read these.
-6. If you ignored the last two warnings, you better [subscribe to this via RSS](/categories/daily-dose-of-pottekkat/index.xml).
+6. If you ignored the last two warnings, you better [subscribe to this via RSS](/dailies/index.xml).
 
 On a positive note, there are photos in some of these!

--- a/content/newsletters/nl-apachecon-soberai-and-slop.md
+++ b/content/newsletters/nl-apachecon-soberai-and-slop.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "Hello from ApacheCon EU!"
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 Hello from Abu Dhabi!

--- a/content/newsletters/nl-apple-intelligence-20-million-jobs-and-gen-z-software-engineers.md
+++ b/content/newsletters/nl-apple-intelligence-20-million-jobs-and-gen-z-software-engineers.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "What do Gen-Z software engineers think of the workplace?"
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 Hello from the only place I call home, Kerala!

--- a/content/newsletters/nl-elections-economics-and-cobol.md
+++ b/content/newsletters/nl-elections-economics-and-cobol.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "There's a lot to talk about."
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 Should I consume less content, or is there a lot happening? Either way, there's a lot to talk about.

--- a/content/newsletters/nl-hanoi-maintainers-and-the-future-of-humanity.md
+++ b/content/newsletters/nl-hanoi-maintainers-and-the-future-of-humanity.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "Greetings from Hanoi!"
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 Hello from Hanoi!

--- a/content/newsletters/nl-open-source-standards-and-updated-newsletter.md
+++ b/content/newsletters/nl-open-source-standards-and-updated-newsletter.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "We are so back!"
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 The newsletter is back with a new format. Again!

--- a/content/newsletters/nl-rug-pulls-comic-sans-link-in-bio.md
+++ b/content/newsletters/nl-rug-pulls-comic-sans-link-in-bio.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "Rug pulls from big tech are inevitable."
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 Have you noticed that this is a link-only newsletter?

--- a/content/newsletters/nl-software-patents-crazy-charlie-and-the-absolutist.md
+++ b/content/newsletters/nl-software-patents-crazy-charlie-and-the-absolutist.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "Also, how do you accidentally run for President?"
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 I spent an absurd amount of time tweaking [my blog](https://navendu.me/) this weekend.

--- a/content/newsletters/nl-wikipedia-reviews-and-the-internet.md
+++ b/content/newsletters/nl-wikipedia-reviews-and-the-internet.md
@@ -5,8 +5,6 @@ draft: false
 ShowToc: true
 TocOpen: true
 summary: "Let's delve into this week's newsletter."
-tags: ["newsletter"]
-categories: ["Newsletter"]
 ---
 
 I’m back from my travels into a productive week at work.

--- a/content/playgrounds/apisix/index.md
+++ b/content/playgrounds/apisix/index.md
@@ -7,8 +7,6 @@ experimental: true
 EnableCodapi: true
 CodapiURL: codapi.navendu.me/v1
 ShowCodeCopyButtons: false
-tags: ["playground", "apisix", "codapi"]
-categories: ["Playground"]
 cover:
   image: "/images/pl-apisix/apisix-logo-banner.jpg"
   alt: "Apache APISIX logo."

--- a/content/playgrounds/nginx/index.md
+++ b/content/playgrounds/nginx/index.md
@@ -7,8 +7,6 @@ experimental: true
 EnableCodapi: true
 CodapiURL: codapi.navendu.me/v1
 ShowCodeCopyButtons: false
-tags: ["playground", "nginx", "codapi"]
-categories: ["Playground"]
 cover:
   image: "/images/pl-nginx/nginx-logo-banner.jpg"
   alt: "Nginx logo."

--- a/content/posts/my-blog-setup-and-writing-process.md
+++ b/content/posts/my-blog-setup-and-writing-process.md
@@ -7,10 +7,10 @@ summary: "I've been writing blogs for almost three years now. Recently, I've bee
 tags: ["blogs", "setup"]
 categories: ["Writing/Blogging"]
 cover:
-    image: "/images/my-blog-setup-and-writing-process/banner-typewriter.jpeg"
-    alt: "A photo of a typewriter."
-    caption: "Photo by [Caryn](https://www.pexels.com/photo/typewriter-keys-938165/)"
-    relative: false
+  image: "/images/my-blog-setup-and-writing-process/banner-typewriter.jpeg"
+  alt: "A photo of a typewriter."
+  caption: "Photo by [Caryn](https://www.pexels.com/photo/typewriter-keys-938165/)"
+  relative: false
 ---
 
 I've been writing blogs for almost three years now. Recently, I've been putting a lot of effort into building and maintaining my blog. This article documents my blog setup and my writing process from idea to publishing.
@@ -51,7 +51,7 @@ I've tried different open source CMS platforms, but none seem easy to migrate to
 
 But, to make my life easier, I use some tools and configurations.
 
-My site contains two types of posts; the [regular blog posts](/) shown on the homepage and [daily logs](/categories/daily-dose-of-pottekkat/). Each of these posts has a custom front matter. I have configured [archetypes](https://gohugo.io/content-management/archetypes/) to create new files with these front matters easily.
+My site contains two types of posts; the [regular blog posts](/) shown on the homepage and [daily logs](/dailies/). Each of these posts has a custom front matter. I have configured [archetypes](https://gohugo.io/content-management/archetypes/) to create new files with these front matters easily.
 
 This makes it easy to create new posts. A new file is created and configured; I just have to worry about the content.
 

--- a/frontmatter.json
+++ b/frontmatter.json
@@ -173,20 +173,6 @@
           "title": "Summary",
           "name": "summary",
           "type": "string"
-        },
-        {
-          "title": "Tags",
-          "name": "tags",
-          "type": "tags",
-          "default": [
-            "daily log"
-          ]
-        },
-        {
-          "title": "Categories",
-          "name": "categories",
-          "type": "categories",
-          "default": "Daily Dose of Pottekkat"
         }
       ]
     },
@@ -232,20 +218,6 @@
           "title": "Summary",
           "name": "summary",
           "type": "string"
-        },
-        {
-          "title": "Tags",
-          "name": "tags",
-          "type": "tags",
-          "default": [
-            "newsletter"
-          ]
-        },
-        {
-          "title": "Categories",
-          "name": "categories",
-          "type": "categories",
-          "default": "Newsletter"
         }
       ]
     }

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -6,7 +6,7 @@
 
 <div id="searchbox">
   <input id="searchInput" autofocus placeholder="{{ .Params.placeholder | default (printf "%s" .Title) }}"
-      aria-label="search" type="search" autocomplete="off" data-omit="Daily Dose of Pottekkat, Newsletter, Playground">
+      aria-label="search" type="search" autocomplete="off" data-omit="dailies, newsletters, playgrounds">
   <ul id="searchResults" aria-label="search results"></ul>
 </div>
 

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,7 +1,7 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Site.RegularPages -}}
     {{- if and (not .Params.searchHidden) (ne .Layout `archives`) (ne .Layout `stats`) (ne .Layout `about`) (ne .Layout `search`) (ne .Layout `subscribe`) }}
-    {{- $.Scratch.Add "index" (dict "title" .Title "content" .Plain "permalink" .Permalink "summary" .Summary "categories" .Params.categories) -}}
+    {{- $.Scratch.Add "index" (dict "title" .Title "content" .Plain "permalink" .Permalink "summary" .Summary "categories" .Params.categories "section" .Section) -}}
     {{- end }}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}

--- a/layouts/dailies/list.html
+++ b/layouts/dailies/list.html
@@ -24,7 +24,7 @@
 
 <div id="searchbox">
   <input id="searchInput" autofocus placeholder="{{ .Params.placeholder | default (printf "Search") }}"
-      aria-label="search" type="search" autocomplete="off" data-show-only="Daily Dose of Pottekkat">
+      aria-label="search" type="search" autocomplete="off" data-show-only="dailies">
   <ul id="searchResults" aria-label="search results"></ul>
 </div>
 

--- a/layouts/dailies/list.html
+++ b/layouts/dailies/list.html
@@ -3,7 +3,7 @@
 <header class="page-header">
   <h1>
     {{ .Title }}
-    <a href="/categories/daily-dose-of-pottekkat/index.xml" title="RSS" aria-label="RSS">
+    <a href="/dailies/index.xml" title="RSS" aria-label="RSS">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
         stroke-linecap="round" stroke-linejoin="round" height="23">
         <path d="M4 11a9 9 0 0 1 9 9" />

--- a/layouts/newsletters/list.html
+++ b/layouts/newsletters/list.html
@@ -16,7 +16,7 @@
 
 <div id="searchbox">
   <input id="searchInput" autofocus placeholder="{{ .Params.placeholder | default (printf "Search") }}"
-      aria-label="search" type="search" autocomplete="off" data-show-only="Newsletter">
+      aria-label="search" type="search" autocomplete="off" data-show-only="newsletters">
   <ul id="searchResults" aria-label="search results"></ul>
 </div>
 


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

remove tags and categories from newsletters and playground, update fastsearch to use section names to filter, add section names to index, update search boxes to use section names instead of category names